### PR TITLE
Move to stable

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,3 +4,4 @@ version = "0.1.0"
 authors = ["Ticki <Ticki@users.noreply.github.com>"]
 
 [dependencies]
+libc = "0.2.8"

--- a/src/extra.rs
+++ b/src/extra.rs
@@ -15,12 +15,12 @@ impl<R: Read> ReadExt for R {
         let _raw = try!(writer.into_raw_mode());
         let mut string = String::with_capacity(30);
 
-        for c in self.chars() {
+        for c in self.bytes() {
             match c {
                 Err(_) => return Err(TerminalError::StdinError),
-                Ok('\0') | Ok('\x03') | Ok('\x04') => return Ok(None),
-                Ok('\n') | Ok('\r') => return Ok(Some(string)),
-                Ok(c) => string.push(c),
+                Ok(b'\0') | Ok(b'\x03') | Ok(b'\x04') => return Ok(None),
+                Ok(b'\n') | Ok(b'\r') => return Ok(Some(string)),
+                Ok(c) => string.push(c as char),
             }
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,3 @@
-#![feature(libc)]
-
 #[warn(missing_docs)]
 
 #[cfg(not(target_os = "redox"))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,3 @@
-#![feature(io)]
 #![feature(libc)]
 
 #[warn(missing_docs)]


### PR DESCRIPTION
- Replace unstable `chars()` by `bytes()` and a binary match. `Read::chars()` is unstable and its semantics unclear: https://github.com/rust-lang/rust/issues/27802
- Use libc from crates.io, as recommended. I'm not sure about building with Redox here, maybe the dependency has to be expressed in another form.
