### PR TITLE
Fix for compilation on Redox

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,28 @@ name = "termion"
 version = "0.1.0"
 authors = ["Ticki <Ticki@users.noreply.github.com>"]
 
-[target.'cfg(unix)'.dependencies]
+[target.i686-unknown-linux-gnu.dependencies]
+libc = "0.2.8"
+
+[target.x86_64-unknown-linux-gnu.dependencies]
+libc = "0.2.8"
+
+[target.i686-unknown-linux-musl.dependencies]
+libc = "0.2.8"
+
+[target.x86_64-unknown-linux-musl.dependencies]
+libc = "0.2.8"
+
+[target.i686-pc-windows-gnu.dependencies]
+libc = "0.2.8"
+
+[target.x86_64-pc-windows-gnu.dependencies]
+libc = "0.2.8"
+
+[target.i686-apple-darwin.dependencies]
+libc = "0.2.8"
+
+[target.x86_64-apple-darwin.dependencies]
 libc = "0.2.8"
 
 [features]


### PR DESCRIPTION
Since Redox sets `cfg(unix)`, but does not have a compatible `libc` crate, more specific matching has to be done. Here are all the class-one targets with the libc crate selected
