### PR TITLE
modify Keys and Events to detect Esc key presses

### DIFF
--- a/examples/keys.rs
+++ b/examples/keys.rs
@@ -23,6 +23,7 @@ fn main() {
             Key::Char(c) => println!("{}", c),
             Key::Alt(c) => println!("^{}", c),
             Key::Ctrl(c) => println!("*{}", c),
+            Key::Esc => println!("ESC"),
             Key::Left => println!("←"),
             Key::Right => println!("→"),
             Key::Up => println!("↑"),

--- a/src/event.rs
+++ b/src/event.rs
@@ -86,6 +86,8 @@ pub enum Key {
     Ctrl(char),
     /// Null byte.
     Null,
+    /// Esc key.
+    Esc,
 
     #[allow(missing_docs)]
     #[doc(hidden)]

--- a/src/input.rs
+++ b/src/input.rs
@@ -244,6 +244,13 @@ mod test {
         assert!(st.next().is_none());
     }
 
+    #[test]
+    fn test_esc_key() {
+        let mut st = b"\x1B".keys();
+        assert_eq!(st.next().unwrap().unwrap(), Key::Esc);
+        assert!(st.next().is_none());
+    }
+
     fn line_match(a: &str, b: Option<&str>) {
         let mut sink = io::sink();
 


### PR DESCRIPTION
The strategy used here is to read two bytes at a time, going on the
assumption that escape sequences will consist of multi byte reads and
solitary Esc key presses will consist of single byte reads.

Tests had to be modified to account for these new multi byte reads by
including dummy bytes when a single byte was previously expected.

Fixes ticki/termion#43
