### PR TITLE
Change is_tty example to conform to new signature

### DIFF
--- a/examples/is_tty.rs
+++ b/examples/is_tty.rs
@@ -3,7 +3,7 @@ extern crate termion;
 use std::fs;
 
 fn main() {
-    if termion::is_tty(fs::File::create("/dev/stdout").unwrap()) {
+    if termion::is_tty(&fs::File::create("/dev/stdout").unwrap()) {
         println!("This is a TTY!");
     } else {
         println!("This is not a TTY :(");


### PR DESCRIPTION
Commit 0d1025c532b06c59898908e3def509f63eaa3257 changed the signature of
is_tty, but the example was not updated.
