### PR TITLE
Add `UnknownCSI` event type

### DIFF
--- a/src/color.rs
+++ b/src/color.rs
@@ -3,9 +3,7 @@
 //! # Example
 //!
 //! ```rust
-//! use termion::{color, style};
-//!
-//! use std::io;
+//! use termion::color;
 //!
 //! fn main() {
 //!     println!("{}Red", color::Fg(color::Red));

--- a/src/event.rs
+++ b/src/event.rs
@@ -96,7 +96,6 @@ pub enum Key {
     /// Esc key.
     Esc,
 
-    #[allow(missing_docs)]
     #[doc(hidden)]
     __IsNotComplete
 }

--- a/src/event.rs
+++ b/src/event.rs
@@ -14,7 +14,7 @@ pub enum Event {
     /// An event that cannot currently be evaluated.
     Unsupported,
     /// A CSI sequence unrecognized by termion. Does not inlude the leading `^[`.
-    UnknownCSI(Vec<u8>),
+    UnknownCsi(Vec<u8>),
 
 }
 
@@ -229,7 +229,7 @@ where I: Iterator<Item = Result<u8, Error>>
                                         64 => MouseEvent::Hold(cx, cy),
                                         96 |
                                         97 => MouseEvent::Press(MouseButton::WheelUp, cx, cy),
-                                        _ => return Ok(Event::UnknownCSI(str_buf.into_bytes())),
+                                        _ => return Ok(Event::UnknownCsi(str_buf.into_bytes())),
                                     };
 
                                     Event::Mouse(event)
@@ -245,13 +245,13 @@ where I: Iterator<Item = Result<u8, Error>>
                                         .collect();
 
                                     if nums.is_empty() {
-                                        return Ok(Event::UnknownCSI(str_buf.into_bytes()));
+                                        return Ok(Event::UnknownCsi(str_buf.into_bytes()));
                                     }
 
                                     // TODO: handle multiple values for key modififiers (ex: values
                                     // [3, 2] means Shift+Delete)
                                     if nums.len() > 1 {
-                                        return Ok(Event::UnknownCSI(str_buf.into_bytes()));
+                                        return Ok(Event::UnknownCsi(str_buf.into_bytes()));
                                     }
 
                                     match nums[0] {
@@ -264,10 +264,10 @@ where I: Iterator<Item = Result<u8, Error>>
                                         v @ 11...15 => Event::Key(Key::F(v - 10)),
                                         v @ 17...21 => Event::Key(Key::F(v - 11)),
                                         v @ 23...24 => Event::Key(Key::F(v - 12)),
-                                        _ => return Ok(Event::UnknownCSI(str_buf.into_bytes())),
+                                        _ => return Ok(Event::UnknownCsi(str_buf.into_bytes())),
                                     }
                                 },
-                                _ => return Ok(Event::UnknownCSI(buf)),
+                                _ => return Ok(Event::UnknownCsi(buf)),
                             }
                         },
                         _ => return error,

--- a/src/raw.rs
+++ b/src/raw.rs
@@ -11,7 +11,7 @@
 //!
 //! # Example
 //!
-//! ```rust,ignore
+//! ```rust,no_run
 //! use termion::raw::IntoRawMode;
 //! use std::io::{Write, stdout};
 //!


### PR DESCRIPTION
When a CSI sequence is not parsed by termion, return a special `UnknownCSI` event including the byte sequence, allowing applications using termion to do their own parsing.