### PR TITLE
Replace UnknownCsi with generalized Event::Unsupported

### DIFF
--- a/src/event.rs
+++ b/src/event.rs
@@ -12,10 +12,7 @@ pub enum Event {
     /// A mouse button press, release or wheel use at specific coordinates.
     Mouse(MouseEvent),
     /// An event that cannot currently be evaluated.
-    Unsupported,
-    /// A CSI sequence unrecognized by termion. Does not inlude the leading `^[`.
-    UnknownCsi(Vec<u8>),
-
+    Unsupported(Vec<u8>),
 }
 
 /// A mouse related event.
@@ -97,210 +94,218 @@ pub enum Key {
     Esc,
 
     #[doc(hidden)]
-    __IsNotComplete
+    __IsNotComplete,
 }
 
 /// Parse an Event from `item` and possibly subsequent bytes through `iter`.
-pub fn parse_event<I>(item: Result<u8, Error>, iter: &mut I) -> Result<Event, Error>
-where I: Iterator<Item = Result<u8, Error>>
+pub fn parse_event<I>(item: u8, iter: &mut I) -> Result<Event, Error>
+    where I: Iterator<Item = Result<u8, Error>>
 {
-    let error = Err(Error::new(ErrorKind::Other, "Could not parse an event"));
+    let error = Error::new(ErrorKind::Other, "Could not parse an event");
     match item {
-        Ok(b'\x1B') => {
+        b'\x1B' => {
+            // This is an escape character, leading a control sequence.
             Ok(match iter.next() {
                 Some(Ok(b'O')) => {
                     match iter.next() {
                         // F1-F4
-                        Some(Ok(val @ b'P' ... b'S')) => Event::Key(Key::F(1 + val - b'P')),
-                        _ => return error,
+                        Some(Ok(val @ b'P'...b'S')) => Event::Key(Key::F(1 + val - b'P')),
+                        _ => return Err(error),
                     }
                 }
                 Some(Ok(b'[')) => {
                     // This is a CSI sequence.
-                    match iter.next() {
-                        Some(Ok(b'D')) => Event::Key(Key::Left),
-                        Some(Ok(b'C')) => Event::Key(Key::Right),
-                        Some(Ok(b'A')) => Event::Key(Key::Up),
-                        Some(Ok(b'B')) => Event::Key(Key::Down),
-                        Some(Ok(b'H')) => Event::Key(Key::Home),
-                        Some(Ok(b'F')) => Event::Key(Key::End),
-                        Some(Ok(b'M')) => {
-                            // X10 emulation mouse encoding: ESC [ CB Cx Cy (6 characters only).
-                            let cb = iter.next().unwrap().unwrap() as i8 - 32;
-                            // (1, 1) are the coords for upper left.
-                            let cx = (iter.next().unwrap().unwrap() as u8).saturating_sub(32) as u16;
-                            let cy = (iter.next().unwrap().unwrap() as u8).saturating_sub(32) as u16;
-                            Event::Mouse(match cb & 0b11 {
-                                0 => {
-                                    if cb & 0x40 != 0 {
-                                        MouseEvent::Press(MouseButton::WheelUp, cx, cy)
-                                    } else {
-                                        MouseEvent::Press(MouseButton::Left, cx, cy)
-                                    }
-                                }
-                                1 => {
-                                    if cb & 0x40 != 0 {
-                                        MouseEvent::Press(MouseButton::WheelDown, cx, cy)
-                                    } else {
-                                        MouseEvent::Press(MouseButton::Middle, cx, cy)
-                                    }
-                                }
-                                2 => MouseEvent::Press(MouseButton::Right, cx, cy),
-                                3 => MouseEvent::Release(cx, cy),
-                                _ => return error,
-                            })
-                        },
-                        Some(Ok(b'<')) => {
-                            // xterm mouse encoding:
-                            // ESC [ < Cb ; Cx ; Cy ; (M or m)
-                            let mut buf = Vec::new();
-                            let mut c = iter.next().unwrap().unwrap();
-                                while match c {
-                                    b'm' | b'M' => false,
-                                    _ => true,
-                                } {
-                                    buf.push(c);
-                                    c = iter.next().unwrap().unwrap();
-                                }
-                            let str_buf = String::from_utf8(buf).unwrap();
-                            let nums = &mut str_buf.split(';');
-
-                            let cb = nums.next().unwrap().parse::<u16>().unwrap();
-                            let cx = nums.next().unwrap().parse::<u16>().unwrap();
-                            let cy = nums.next().unwrap().parse::<u16>().unwrap();
-
-                            let event = match cb {
-                                0...2 | 64...65 => {
-                                    let button = match cb {
-                                        0 => MouseButton::Left,
-                                        1 => MouseButton::Middle,
-                                        2 => MouseButton::Right,
-                                        64 => MouseButton::WheelUp,
-                                        65 => MouseButton::WheelDown,
-                                        _ => return error,
-                                    };
-                                    match c {
-                                        b'M' => MouseEvent::Press(button, cx, cy),
-                                        b'm' => MouseEvent::Release(cx, cy),
-                                        _ => return error,
-                                    }
-                                }
-                                32 => MouseEvent::Hold(cx, cy),
-                                _ => return error,
-                            };
-
-                            Event::Mouse(event)
-                        },
-                        Some(Ok(c @ b'0'...b'9')) => {
-                            // Numbered escape code.
-                            let mut buf = Vec::new();
-                            buf.push(c);
-                            let mut c = iter.next().unwrap().unwrap();
-                            // The final byte of a CSI sequence can be in the range 64-126, so
-                            // let's keep reading anything else.
-                            while c < 64 || c > 126 {
-                                buf.push(c);
-                                c = iter.next().unwrap().unwrap();
-                            }
-                            // Include the terminal char in the buffer.
-                            // We'll want it if we return an unknown sequence.
-                            buf.push(c);
-
-                            match c {
-                                // rxvt mouse encoding:
-                                // ESC [ Cb ; Cx ; Cy ; M
-                                b'M' => {
-                                    let str_buf = String::from_utf8(buf).unwrap();
-
-                                    // 
-                                    let nums: Vec<u16> = str_buf[..str_buf.len()-1].split(';')
-                                        .map(|n| n.parse().unwrap())
-                                        .collect();
-
-                                    let cb = nums[0];
-                                    let cx = nums[1];
-                                    let cy = nums[2];
-
-                                    let event = match cb {
-                                        32 => MouseEvent::Press(MouseButton::Left, cx, cy),
-                                        33 => MouseEvent::Press(MouseButton::Middle, cx, cy),
-                                        34 => MouseEvent::Press(MouseButton::Right, cx, cy),
-                                        35 => MouseEvent::Release(cx, cy),
-                                        64 => MouseEvent::Hold(cx, cy),
-                                        96 |
-                                        97 => MouseEvent::Press(MouseButton::WheelUp, cx, cy),
-                                        _ => return Ok(Event::UnknownCsi(str_buf.into_bytes())),
-                                    };
-
-                                    Event::Mouse(event)
-                                },
-                                // Special key code.
-                                b'~' => {
-                                    let str_buf = String::from_utf8(buf).unwrap();
-
-                                    // This CSI sequence can be a list of semicolon-separated
-                                    // numbers.
-                                    let nums: Vec<u8> = str_buf[..str_buf.len()-1].split(';')
-                                        .map(|n| n.parse().unwrap())
-                                        .collect();
-
-                                    if nums.is_empty() {
-                                        return Ok(Event::UnknownCsi(str_buf.into_bytes()));
-                                    }
-
-                                    // TODO: handle multiple values for key modififiers (ex: values
-                                    // [3, 2] means Shift+Delete)
-                                    if nums.len() > 1 {
-                                        return Ok(Event::UnknownCsi(str_buf.into_bytes()));
-                                    }
-
-                                    match nums[0] {
-                                        1 | 7 => Event::Key(Key::Home),
-                                        2 => Event::Key(Key::Insert),
-                                        3 => Event::Key(Key::Delete),
-                                        4 | 8 => Event::Key(Key::End),
-                                        5 => Event::Key(Key::PageUp),
-                                        6 => Event::Key(Key::PageDown),
-                                        v @ 11...15 => Event::Key(Key::F(v - 10)),
-                                        v @ 17...21 => Event::Key(Key::F(v - 11)),
-                                        v @ 23...24 => Event::Key(Key::F(v - 12)),
-                                        _ => return Ok(Event::UnknownCsi(str_buf.into_bytes())),
-                                    }
-                                },
-                                _ => return Ok(Event::UnknownCsi(buf)),
-                            }
-                        },
-                        _ => return error,
-                    }
+                    parse_csi(iter).ok_or(error)?
                 }
                 Some(Ok(c)) => {
                     let ch = parse_utf8_char(c, iter);
                     Event::Key(Key::Alt(try!(ch)))
                 }
-                Some(Err(_)) | None => return error,
+                Some(Err(_)) | None => return Err(error),
             })
         }
-        Ok(b'\n') | Ok(b'\r') => Ok(Event::Key(Key::Char('\n'))),
-        Ok(b'\t') => Ok(Event::Key(Key::Char('\t'))),
-        Ok(b'\x7F') => Ok(Event::Key(Key::Backspace)),
-        Ok(c @ b'\x01'...b'\x1A') => Ok(Event::Key(Key::Ctrl((c as u8 - 0x1 + b'a') as char))),
-        Ok(c @ b'\x1C'...b'\x1F') => {
-            Ok(Event::Key(Key::Ctrl((c as u8 - 0x1C + b'4') as char)))
-        }
-        Ok(b'\0') => Ok(Event::Key(Key::Null)),
-        Ok(c) => {
+        b'\n' | b'\r' => Ok(Event::Key(Key::Char('\n'))),
+        b'\t' => Ok(Event::Key(Key::Char('\t'))),
+        b'\x7F' => Ok(Event::Key(Key::Backspace)),
+        c @ b'\x01'...b'\x1A' => Ok(Event::Key(Key::Ctrl((c as u8 - 0x1 + b'a') as char))),
+        c @ b'\x1C'...b'\x1F' => Ok(Event::Key(Key::Ctrl((c as u8 - 0x1C + b'4') as char))),
+        b'\0' => Ok(Event::Key(Key::Null)),
+        c => {
             Ok({
                 let ch = parse_utf8_char(c, iter);
                 Event::Key(Key::Char(try!(ch)))
             })
         }
-        Err(e) => Err(e),
     }
+}
+
+/// Parses a CSI sequence, just after reading ^[
+///
+/// Returns None if an unrecognized sequence is found.
+fn parse_csi<I>(iter: &mut I) -> Option<Event>
+    where I: Iterator<Item = Result<u8, Error>>
+{
+    Some(match iter.next() {
+        Some(Ok(b'D')) => Event::Key(Key::Left),
+        Some(Ok(b'C')) => Event::Key(Key::Right),
+        Some(Ok(b'A')) => Event::Key(Key::Up),
+        Some(Ok(b'B')) => Event::Key(Key::Down),
+        Some(Ok(b'H')) => Event::Key(Key::Home),
+        Some(Ok(b'F')) => Event::Key(Key::End),
+        Some(Ok(b'M')) => {
+            // X10 emulation mouse encoding: ESC [ CB Cx Cy (6 characters only).
+            let mut next = || iter.next().unwrap().unwrap();
+
+            let cb = next() as i8 - 32;
+            // (1, 1) are the coords for upper left.
+            let cx = next().saturating_sub(32) as u16;
+            let cy = next().saturating_sub(32) as u16;
+            Event::Mouse(match cb & 0b11 {
+                0 => {
+                    if cb & 0x40 != 0 {
+                        MouseEvent::Press(MouseButton::WheelUp, cx, cy)
+                    } else {
+                        MouseEvent::Press(MouseButton::Left, cx, cy)
+                    }
+                }
+                1 => {
+                    if cb & 0x40 != 0 {
+                        MouseEvent::Press(MouseButton::WheelDown, cx, cy)
+                    } else {
+                        MouseEvent::Press(MouseButton::Middle, cx, cy)
+                    }
+                }
+                2 => MouseEvent::Press(MouseButton::Right, cx, cy),
+                3 => MouseEvent::Release(cx, cy),
+                _ => return None,
+            })
+        }
+        Some(Ok(b'<')) => {
+            // xterm mouse encoding:
+            // ESC [ < Cb ; Cx ; Cy ; (M or m)
+            let mut buf = Vec::new();
+            let mut c = iter.next().unwrap().unwrap();
+            while match c {
+                b'm' | b'M' => false,
+                _ => true,
+            } {
+                buf.push(c);
+                c = iter.next().unwrap().unwrap();
+            }
+            let str_buf = String::from_utf8(buf).unwrap();
+            let nums = &mut str_buf.split(';');
+
+            let cb = nums.next().unwrap().parse::<u16>().unwrap();
+            let cx = nums.next().unwrap().parse::<u16>().unwrap();
+            let cy = nums.next().unwrap().parse::<u16>().unwrap();
+
+            let event = match cb {
+                0...2 | 64...65 => {
+                    let button = match cb {
+                        0 => MouseButton::Left,
+                        1 => MouseButton::Middle,
+                        2 => MouseButton::Right,
+                        64 => MouseButton::WheelUp,
+                        65 => MouseButton::WheelDown,
+                        _ => unreachable!(),
+                    };
+                    match c {
+                        b'M' => MouseEvent::Press(button, cx, cy),
+                        b'm' => MouseEvent::Release(cx, cy),
+                        _ => return None,
+                    }
+                }
+                32 => MouseEvent::Hold(cx, cy),
+                _ => return None,
+            };
+
+            Event::Mouse(event)
+        }
+        Some(Ok(c @ b'0'...b'9')) => {
+            // Numbered escape code.
+            let mut buf = Vec::new();
+            buf.push(c);
+            let mut c = iter.next().unwrap().unwrap();
+            // The final byte of a CSI sequence can be in the range 64-126, so
+            // let's keep reading anything else.
+            while c < 64 || c > 126 {
+                buf.push(c);
+                c = iter.next().unwrap().unwrap();
+            }
+
+            match c {
+                // rxvt mouse encoding:
+                // ESC [ Cb ; Cx ; Cy ; M
+                b'M' => {
+                    let str_buf = String::from_utf8(buf).unwrap();
+
+                    let nums: Vec<u16> = str_buf
+                        .split(';')
+                        .map(|n| n.parse().unwrap())
+                        .collect();
+
+                    let cb = nums[0];
+                    let cx = nums[1];
+                    let cy = nums[2];
+
+                    let event = match cb {
+                        32 => MouseEvent::Press(MouseButton::Left, cx, cy),
+                        33 => MouseEvent::Press(MouseButton::Middle, cx, cy),
+                        34 => MouseEvent::Press(MouseButton::Right, cx, cy),
+                        35 => MouseEvent::Release(cx, cy),
+                        64 => MouseEvent::Hold(cx, cy),
+                        96 | 97 => MouseEvent::Press(MouseButton::WheelUp, cx, cy),
+                        _ => return None,
+                    };
+
+                    Event::Mouse(event)
+                }
+                // Special key code.
+                b'~' => {
+                    let str_buf = String::from_utf8(buf).unwrap();
+
+                    // This CSI sequence can be a list of semicolon-separated
+                    // numbers.
+                    let nums: Vec<u8> = str_buf
+                        .split(';')
+                        .map(|n| n.parse().unwrap())
+                        .collect();
+
+                    if nums.is_empty() {
+                        return None;
+                    }
+
+                    // TODO: handle multiple values for key modififiers (ex: values
+                    // [3, 2] means Shift+Delete)
+                    if nums.len() > 1 {
+                        return None;
+                    }
+
+                    match nums[0] {
+                        1 | 7 => Event::Key(Key::Home),
+                        2 => Event::Key(Key::Insert),
+                        3 => Event::Key(Key::Delete),
+                        4 | 8 => Event::Key(Key::End),
+                        5 => Event::Key(Key::PageUp),
+                        6 => Event::Key(Key::PageDown),
+                        v @ 11...15 => Event::Key(Key::F(v - 10)),
+                        v @ 17...21 => Event::Key(Key::F(v - 11)),
+                        v @ 23...24 => Event::Key(Key::F(v - 12)),
+                        _ => return None,
+                    }
+                }
+                _ => return None,
+            }
+        }
+        _ => return None,
+    })
+
 }
 
 /// Parse `c` as either a single byte ASCII char or a variable size UTF-8 char.
 fn parse_utf8_char<I>(c: u8, iter: &mut I) -> Result<char, Error>
-    where I: Iterator<Item = Result<u8, Error>> {
+    where I: Iterator<Item = Result<u8, Error>>
+{
     let error = Err(Error::new(ErrorKind::Other, "Input character is not valid UTF-8"));
     if c.is_ascii() {
         Ok(c as char)
@@ -311,9 +316,11 @@ fn parse_utf8_char<I>(c: u8, iter: &mut I) -> Result<char, Error>
         loop {
             bytes.push(iter.next().unwrap().unwrap());
             if let Ok(st) = str::from_utf8(bytes) {
-                return Ok(st.chars().next().unwrap())
+                return Ok(st.chars().next().unwrap());
             }
-            if bytes.len() >= 4 { return error; }
+            if bytes.len() >= 4 {
+                return error;
+            }
         }
     }
 }


### PR DESCRIPTION
Instead of having a special "Unknown" enum variant for CSI sequence, simply record any unknown byte sequence sent to `event::parse_event` and includes that in the `event::Unsupported` variant.

This is cleaner and more generic.

Also splits the CSI parsing part into its own function.

Note: I ran `rustfmt`, but there were no `rustfmt.toml` configuration, so it used the defaults.
If this is not satisfactory, do you have a better config to use instead?