### PR TITLE
Add travis integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+language: rust
+cache: cargo
+rust:
+    - stable
+    - beta
+    - nightly
+script:
+    - cargo build --verbose
+    - cargo test --verbose
+    - cargo test --release --verbose

--- a/examples/rainbow.rs
+++ b/examples/rainbow.rs
@@ -1,5 +1,3 @@
-#![feature(step_by)]
-
 extern crate termion;
 
 use termion::event::Key;
@@ -10,8 +8,10 @@ use std::io::{Write, stdout, stdin};
 fn rainbow<W: Write>(stdout: &mut W, blue: u8) {
     write!(stdout, "{}{}", termion::cursor::Goto(1, 1), termion::clear::All).unwrap();
 
-    for red in (0..255).step_by(8 as u8) {
-        for green in (0..255).step_by(4) {
+    for red in 0..32 {
+        let red = red * 8;
+        for green in 0..64 {
+            let green = green * 4;
             write!(stdout, "{} ", termion::color::Bg(termion::color::Rgb(red, green, blue))).unwrap();
         }
         write!(stdout, "\n\r").unwrap();
@@ -24,7 +24,7 @@ fn main() {
     let stdin = stdin();
     let mut stdout = stdout().into_raw_mode().unwrap();
 
-    writeln!(stdout, "{}{}{}Use the arrow keys to change the blue in the rainbow.",
+    writeln!(stdout, "{}{}{}Use the up/down arrow keys to change the blue in the rainbow.",
            termion::clear::All,
            termion::cursor::Goto(1, 1),
            termion::cursor::Hide).unwrap();


### PR DESCRIPTION
This configures travis to build and test termion on the stable, beta and nightly branches.

I updated the rainbow example to work on stable (removed the `step_by` feature), which admittedly isn't as pretty. Possible solutions are:
* Wait for `step_by` to be stable before integrating travis
* Add conditional to only compile rainbow example on nightly
* Use manual multiplications for now, and update back to `step_by` once it is stable