### PR TITLE
Replace most `std::io::Write::write` with `write_all`

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,16 +154,16 @@ fn main() {
     let stdin = stdin();
     let mut stdin = stdin.lock();
 
-    stdout.write(b"password: ").unwrap();
+    stdout.write_all(b"password: ").unwrap();
     stdout.flush().unwrap();
 
     let pass = stdin.read_passwd(&mut stdout);
 
     if let Ok(Some(pass)) = pass {
-        stdout.write(pass.as_bytes()).unwrap();
-        stdout.write(b"\n").unwrap();
+        stdout.write_all(pass.as_bytes()).unwrap();
+        stdout.write_all(b"\n").unwrap();
     } else {
-        stdout.write(b"Error\n").unwrap();
+        stdout.write_all(b"Error\n").unwrap();
     }
 }
 ```

--- a/examples/async.rs
+++ b/examples/async.rs
@@ -25,10 +25,10 @@ fn main() {
         stdout.flush().unwrap();
 
         thread::sleep(Duration::from_millis(50));
-        stdout.write(b"# ").unwrap();
+        stdout.write_all(b"# ").unwrap();
         stdout.flush().unwrap();
         thread::sleep(Duration::from_millis(50));
-        stdout.write(b"\r #").unwrap();
+        stdout.write_all(b"\r #").unwrap();
         write!(stdout, "{}", termion::cursor::Goto(1, 1)).unwrap();
         stdout.flush().unwrap();
     }

--- a/examples/read.rs
+++ b/examples/read.rs
@@ -9,15 +9,15 @@ fn main() {
     let stdin = stdin();
     let mut stdin = stdin.lock();
 
-    stdout.write(b"password: ").unwrap();
+    stdout.write_all(b"password: ").unwrap();
     stdout.flush().unwrap();
 
     let pass = stdin.read_passwd(&mut stdout);
 
     if let Ok(Some(pass)) = pass {
-        stdout.write(pass.as_bytes()).unwrap();
-        stdout.write(b"\n").unwrap();
+        stdout.write_all(pass.as_bytes()).unwrap();
+        stdout.write_all(b"\n").unwrap();
     } else {
-        stdout.write(b"Error\n").unwrap();
+        stdout.write_all(b"Error\n").unwrap();
     }
 }

--- a/src/input.rs
+++ b/src/input.rs
@@ -160,7 +160,7 @@ pub struct MouseTerminal<W: Write> {
 
 impl<W: Write> From<W> for MouseTerminal<W> {
     fn from(mut from: W) -> MouseTerminal<W> {
-        from.write(ENTER_MOUSE_SEQUENCE.as_bytes()).unwrap();
+        from.write_all(ENTER_MOUSE_SEQUENCE.as_bytes()).unwrap();
 
         MouseTerminal { term: from }
     }
@@ -168,7 +168,7 @@ impl<W: Write> From<W> for MouseTerminal<W> {
 
 impl<W: Write> Drop for MouseTerminal<W> {
     fn drop(&mut self) {
-        self.term.write(EXIT_MOUSE_SEQUENCE.as_bytes()).unwrap();
+        self.term.write_all(EXIT_MOUSE_SEQUENCE.as_bytes()).unwrap();
     }
 }
 

--- a/src/raw.rs
+++ b/src/raw.rs
@@ -141,6 +141,6 @@ mod test {
     fn test_into_raw_mode() {
         let mut out = stdout().into_raw_mode().unwrap();
 
-        out.write(b"this is a test, muahhahahah").unwrap();
+        out.write_all(b"this is a test, muahhahahah").unwrap();
     }
 }


### PR DESCRIPTION
`std::io::Write` doesn't guarantees that it will write everything, and could even return a non-fatal `ErrorKind::Interrupted` error.
`write_all` has exactly the code required to deal with this.

In most cases, the receiving `Write` has enough buffer to take all the input, which is why this was never an issue in practice, but it was still a dangerous thing to do.

The remaining `write()` are actual legit uses.