### PR TITLE
Fix 64 bit build for musl and android

### DIFF
--- a/src/size.rs
+++ b/src/size.rs
@@ -31,17 +31,9 @@ fn tiocgwinsz() -> u32 {
 }
 
 #[cfg(any(target_env = "musl", target_os = "android"))]
-#[cfg(target_pointer_width = "32")]
 fn tiocgwinsz() -> i32 {
     use termios::TIOCGWINSZ;
     TIOCGWINSZ as i32
-}
-
-#[cfg(target_os = "android")]
-#[cfg(target_pointer_width = "64")]
-fn tiocgwinsz() -> i64 {
-    use termios::TIOCGWINSZ;
-    TIOCGWINSZ as i64
 }
 
 /// Get the size of the terminal.


### PR DESCRIPTION
Both musl and android use c_int as the second argument of ioctl. And c_int is i32 on these platform even in 64 bit.

Fix #87 