### PR TITLE
Add support for missing xterm mouse release code

### DIFF
--- a/src/event.rs
+++ b/src/event.rs
@@ -182,7 +182,7 @@ fn parse_csi<I>(iter: &mut I) -> Option<Event>
         }
         Some(Ok(b'<')) => {
             // xterm mouse encoding:
-            // ESC [ < Cb ; Cx ; Cy ; (M or m)
+            // ESC [ < Cb ; Cx ; Cy (;) (M or m)
             let mut buf = Vec::new();
             let mut c = iter.next().unwrap().unwrap();
             while match c {
@@ -216,6 +216,7 @@ fn parse_csi<I>(iter: &mut I) -> Option<Event>
                     }
                 }
                 32 => MouseEvent::Hold(cx, cy),
+                3 => MouseEvent::Release(cx, cy),
                 _ => return None,
             };
 


### PR DESCRIPTION
Using alacritty with mouse support i encountered `Unsupported([27, 91, 60, 51, 59, 52, 54, 59, 49, 48, 109])` which translates to `"\x1B[<3;46;10m"`.

Codes of the form `ESC [ < 3 ; Cx ; Cy m` represent a mouse release, this patch adds support for them. 