### PR TITLE
Fix terminal size ioctl number on *BSD

### DIFF
--- a/src/termios.rs
+++ b/src/termios.rs
@@ -3,10 +3,10 @@ use std::mem;
 
 pub use libc::termios as Termios;
 
-#[cfg(not(target_os = "macos"))]
+#[cfg(target_os = "linux")]
 pub const TIOCGWINSZ: usize = 0x00005413;
 
-#[cfg(target_os = "macos")]
+#[cfg(not(target_os = "linux"))]
 pub const TIOCGWINSZ: usize = 0x40087468;
 
 extern {


### PR DESCRIPTION
At least on FreeBSD and OpenBSD, `TIOCGWINSZ == 0x40087468` just like on
macOS, so change the definition from not-macOS/macOS to Linux/non-Linux.

<img width="776" alt="2017-03-24 22_08_30-tmux_greg_ _usr_home_greg_src_github com_redox-os_ion_2 2 ruunvald" src="https://cloud.githubusercontent.com/assets/208340/24309841/74be98ca-10de-11e7-993f-ed0a1e139eef.png">
