### PR TITLE
run travis builds on osx also

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,11 @@ rust:
     - stable
     - beta
     - nightly
+os:
+    - linux
+    - osx
 script:
-    - cargo build --verbose
-    - cargo test --verbose
-    - cargo test --release --verbose
+    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then FAKETTY="script -q /dev/null"; fi
+    - $FAKETTY cargo build --verbose
+    - $FAKETTY cargo test --verbose
+    - $FAKETTY cargo test --release --verbose


### PR DESCRIPTION
If you are interested, this will run the travis builds on osx also. It uses `script` to allocate a pty so that tests that rely on the existence of a tty can have one.