### PR TITLE
Add an Iterator on Read that provides both the parsed event and the byte sequence that defines it

### DIFF
--- a/src/input.rs
+++ b/src/input.rs
@@ -27,15 +27,28 @@ impl<R: Read> Iterator for Keys<R> {
 }
 
 /// An iterator over input events.
-pub struct Events<R> {
-    source: R,
-    leftover: Option<u8>,
+pub struct Events<R>  {
+    inner: EventsAndRaw<R>
 }
 
 impl<R: Read> Iterator for Events<R> {
     type Item = Result<Event, io::Error>;
 
     fn next(&mut self) -> Option<Result<Event, io::Error>> {
+        self.inner.next().map(|tuple| tuple.map(|(event, _raw)| event))
+    }
+}
+
+/// An iterator over input events and the bytes that define them.
+pub struct EventsAndRaw<R> {
+    source: R,
+    leftover: Option<u8>,
+}
+
+impl<R: Read> Iterator for EventsAndRaw<R> {
+    type Item = Result<(Event, Vec<u8>), io::Error>;
+
+    fn next(&mut self) -> Option<Result<(Event, Vec<u8>), io::Error>> {
         let mut source = &mut self.source;
 
         if let Some(c) = self.leftover {
@@ -53,7 +66,7 @@ impl<R: Read> Iterator for Events<R> {
             Ok(0) => return None,
             Ok(1) => {
                 match buf[0] {
-                    b'\x1B' => Ok(Event::Key(Key::Esc)),
+                    b'\x1B' => Ok((Event::Key(Key::Esc), vec![b'\x1B'])),
                     c => parse_event(c, &mut source.bytes()),
                 }
             }
@@ -75,7 +88,7 @@ impl<R: Read> Iterator for Events<R> {
     }
 }
 
-fn parse_event<I>(item: u8, iter: &mut I) -> Result<Event, io::Error>
+fn parse_event<I>(item: u8, iter: &mut I) -> Result<(Event, Vec<u8>), io::Error>
     where I: Iterator<Item = Result<u8, io::Error>>
 {
     let mut buf = vec![item];
@@ -85,7 +98,7 @@ fn parse_event<I>(item: u8, iter: &mut I) -> Result<Event, io::Error>
                                     });
         event::parse_event(item, &mut iter)
     };
-    result.or(Ok(Event::Unsupported(buf)))
+    result.or(Ok(Event::Unsupported(buf.clone()))).map(|e| (e, buf))
 }
 
 
@@ -113,11 +126,11 @@ pub trait TermRead {
     }
 }
 
-impl<R: Read> TermRead for R {
+
+impl<R: Read + TermReadEventsAndRaw> TermRead for R {
     fn events(self) -> Events<Self> {
         Events {
-            source: self,
-            leftover: None,
+            inner: self.events_and_raw()
         }
     }
     fn keys(self) -> Keys<Self> {
@@ -142,6 +155,21 @@ impl<R: Read> TermRead for R {
         let string = try!(String::from_utf8(buf)
             .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e)));
         Ok(Some(string))
+    }
+}
+
+/// Extension to `TermRead` trait. A separate trait in order to maintain backwards compatibility.
+pub trait TermReadEventsAndRaw {
+    /// An iterator over input events and the bytes that define them.
+    fn events_and_raw(self) -> EventsAndRaw<Self> where Self: Sized;
+}
+
+impl<R: Read> TermReadEventsAndRaw for R {
+    fn events_and_raw(self) -> EventsAndRaw<Self> {
+        EventsAndRaw {
+            source: self,
+            leftover: None,
+        }
     }
 }
 
@@ -239,6 +267,38 @@ mod test {
                    Event::Mouse(MouseEvent::Release(2, 4)));
         assert_eq!(i.next().unwrap().unwrap(), Event::Key(Key::Char('b')));
         assert!(i.next().is_none());
+    }
+
+    #[test]
+    fn test_events_and_raw() {
+        let input = b"\x1B[\x00bc\x7F\x1B[D\
+                    \x1B[M\x00\x22\x24\x1B[<0;2;4;M\x1B[32;2;4M\x1B[<0;2;4;m\x1B[35;2;4Mb";
+        let mut output = Vec::<u8>::new();
+        {
+            let mut i = input.events_and_raw().map(|res| res.unwrap())
+                .inspect(|&(_, ref raw)| { output.extend(raw); }).map(|(event, _)| event);
+
+            assert_eq!(i.next().unwrap(),
+            Event::Unsupported(vec![0x1B, b'[', 0x00]));
+            assert_eq!(i.next().unwrap(), Event::Key(Key::Char('b')));
+            assert_eq!(i.next().unwrap(), Event::Key(Key::Char('c')));
+            assert_eq!(i.next().unwrap(), Event::Key(Key::Backspace));
+            assert_eq!(i.next().unwrap(), Event::Key(Key::Left));
+            assert_eq!(i.next().unwrap(),
+            Event::Mouse(MouseEvent::Press(MouseButton::WheelUp, 2, 4)));
+            assert_eq!(i.next().unwrap(),
+            Event::Mouse(MouseEvent::Press(MouseButton::Left, 2, 4)));
+            assert_eq!(i.next().unwrap(),
+            Event::Mouse(MouseEvent::Press(MouseButton::Left, 2, 4)));
+            assert_eq!(i.next().unwrap(),
+            Event::Mouse(MouseEvent::Release(2, 4)));
+            assert_eq!(i.next().unwrap(),
+            Event::Mouse(MouseEvent::Release(2, 4)));
+            assert_eq!(i.next().unwrap(), Event::Key(Key::Char('b')));
+            assert!(i.next().is_none());
+        }
+
+        assert_eq!(input.iter().map(|b| *b).collect::<Vec<u8>>(), output)
     }
 
     #[test]


### PR DESCRIPTION
This is useful, e.g., for implementing a terminal multiplexer where the raw input should in some cases be passed on to another tty.

Some thoughts on the implementation:
- The function that creates the trait is implemented in a separate extension trait. This is kind of ugly, but (as far as I understand) necessary to ensure backwards compatibility. Although I don't see why the would, users may have implemented `TermRead` for their own types. My suggestion is to provide the newly added function `events_and_raw` in a separate trait for following point releases, but merge it into `TermRead` in a future 2.0 release of Termion.
- The byte sequence is provided as a `Vec<u8>`. This follows the definition of Event::Unsupported. Other options may include `Box<[u8]>`, which is smaller on the stack (as far as i know), but less versatile. We could also pull in smallvec and use something like `SmallVec4<u8>`, but I am not sure if this is worth it. Tell me if you would like me to change the type.