### PR TITLE
Implement size and is_tty with termios on Redox

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,3 +11,8 @@ exclude = ["target", "CHANGELOG.md", "image.png", "Cargo.lock"]
 
 [target.'cfg(not(target_os = "redox"))'.dependencies]
 libc = "0.2.8"
+
+
+[target.'cfg(target_os = "redox")'.dependencies]
+redox_syscall = "0.1"
+redox_termios = "0.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,12 @@ extern crate libc;
 #[cfg(not(target_os = "redox"))]
 mod termios;
 
+#[cfg(target_os = "redox")]
+extern crate redox_termios;
+
+#[cfg(target_os = "redox")]
+extern crate syscall;
+
 mod async;
 pub use async::{AsyncReader, async_stdin};
 

--- a/src/tty.rs
+++ b/src/tty.rs
@@ -11,8 +11,15 @@ pub fn is_tty<T: AsRawFd>(stream: &T) -> bool {
 
 /// This will panic.
 #[cfg(target_os = "redox")]
-pub fn is_tty<T: AsRawFd>(_stream: &T) -> bool {
-    unimplemented!();
+pub fn is_tty<T: AsRawFd>(stream: &T) -> bool {
+    use syscall;
+
+    if let Ok(fd) = syscall::dup(stream.as_raw_fd(), b"termios") {
+        let _ = syscall::close(fd);
+        true
+    } else {
+        false
+    }
 }
 
 /// Get the TTY device.


### PR DESCRIPTION
This will use the magical new Redox termios library to implement size and is_tty.