### PR TITLE
Reduce amount of unwraps

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -18,7 +18,9 @@ impl error::Error for Error {
             ErrorKind::ParseInt(ref e) => e.description(),
             ErrorKind::FromUtf8(ref e) => e.description(),
 
+            ErrorKind::CursorPosDetectionTimeout => "Cursor position detection timed out",
             ErrorKind::InvalidUtf8InputChar => "Input character is not valid UTF-8",
+            ErrorKind::NoCursorBracket => "No cursor bracket found",
             ErrorKind::UnableToParseEvent => "Could not parse an event",
             ErrorKind::UnexpectedIterEnd => "Unexpected end of an iterator",
         }
@@ -30,7 +32,9 @@ impl error::Error for Error {
             ErrorKind::ParseInt(ref e) => e.cause(),
             ErrorKind::FromUtf8(ref e) => e.cause(),
 
+            ErrorKind::CursorPosDetectionTimeout => None,
             ErrorKind::InvalidUtf8InputChar => None,
+            ErrorKind::NoCursorBracket => None,
             ErrorKind::UnableToParseEvent => None,
             ErrorKind::UnexpectedIterEnd => None,
         }
@@ -82,7 +86,9 @@ pub enum ErrorKind {
     ParseInt(::std::num::ParseIntError),
     FromUtf8(::std::string::FromUtf8Error),
 
+    CursorPosDetectionTimeout,
     InvalidUtf8InputChar,
+    NoCursorBracket,
     UnableToParseEvent,
     UnexpectedIterEnd,
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,88 @@
+use std::error;
+use std::fmt;
+use std::result;
+
+
+pub type Result<T> = result::Result<T, Error>;
+
+#[derive(Debug)]
+pub struct Error {
+    kind: ErrorKind,
+    //cause: Box<error::Error>,
+}
+
+impl error::Error for Error {
+    fn description(&self) -> &str {
+        match self.kind {
+            ErrorKind::Io(ref e) => e.description(),
+            ErrorKind::ParseInt(ref e) => e.description(),
+            ErrorKind::FromUtf8(ref e) => e.description(),
+
+            ErrorKind::InvalidUtf8InputChar => "Input character is not valid UTF-8",
+            ErrorKind::UnableToParseEvent => "Could not parse an event",
+            ErrorKind::UnexpectedIterEnd => "Unexpected end of an iterator",
+        }
+    }
+
+    fn cause(&self) -> Option<&error::Error> {
+        match self.kind {
+            ErrorKind::Io(ref e) => e.cause(),
+            ErrorKind::ParseInt(ref e) => e.cause(),
+            ErrorKind::FromUtf8(ref e) => e.cause(),
+
+            ErrorKind::InvalidUtf8InputChar => None,
+            ErrorKind::UnableToParseEvent => None,
+            ErrorKind::UnexpectedIterEnd => None,
+        }
+    }
+}
+
+impl From<ErrorKind> for Error {
+    fn from(e: ErrorKind) -> Error {
+        Error {
+            kind: e,
+        }
+    }
+}
+
+impl From<::std::io::Error> for Error {
+    fn from(e: ::std::io::Error) -> Error {
+        ErrorKind::Io(e).into()
+    }
+}
+
+impl From<::std::num::ParseIntError> for Error {
+    fn from(e: ::std::num::ParseIntError) -> Error {
+        ErrorKind::ParseInt(e).into()
+    }
+}
+
+impl From<::std::string::FromUtf8Error> for Error {
+    fn from(e: ::std::string::FromUtf8Error) -> Error {
+        ErrorKind::FromUtf8(e).into()
+    }
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self.kind {
+            ErrorKind::Io(ref e) => fmt::Display::fmt(e, f),
+            ErrorKind::ParseInt(ref e) => fmt::Display::fmt(e, f),
+            ErrorKind::FromUtf8(ref e) => fmt::Display::fmt(e, f),
+
+            _ => f.write_str(error::Error::description(self)),
+        }
+    }
+}
+
+
+#[derive(Debug)]
+pub enum ErrorKind {
+    Io(::std::io::Error),
+    ParseInt(::std::num::ParseIntError),
+    FromUtf8(::std::string::FromUtf8Error),
+
+    InvalidUtf8InputChar,
+    UnableToParseEvent,
+    UnexpectedIterEnd,
+}

--- a/src/event.rs
+++ b/src/event.rs
@@ -4,6 +4,7 @@ use std::ascii::AsciiExt;
 use std::str;
 
 use error::{self, ErrorKind};
+use utils::checked_next;
 
 /// An event reported by the terminal.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -322,7 +323,7 @@ fn parse_utf8_char<I>(c: u8, iter: &mut I) -> error::Result<char>
                 Some(Ok(next)) => {
                     bytes.push(next);
                     if let Ok(st) = str::from_utf8(bytes) {
-                        return st.chars().next().ok_or(ErrorKind::UnexpectedIterEnd.into());
+                        return checked_next(&mut st.chars());
                     }
                     if bytes.len() >= 4 {
                         return Err(error);
@@ -334,11 +335,6 @@ fn parse_utf8_char<I>(c: u8, iter: &mut I) -> error::Result<char>
     }
 }
 
-fn checked_next<T, I>(iterator: &mut I) -> error::Result<T>
-    where I: Iterator<Item = T>
-{
-    iterator.next().ok_or(ErrorKind::UnexpectedIterEnd.into())
-}
 
 
 #[cfg(test)]

--- a/src/event.rs
+++ b/src/event.rs
@@ -1,8 +1,9 @@
 //! Mouse and key events.
 
-use std::io::{Error, ErrorKind};
 use std::ascii::AsciiExt;
 use std::str;
+
+use error::{self, ErrorKind};
 
 /// An event reported by the terminal.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -98,223 +99,218 @@ pub enum Key {
 }
 
 /// Parse an Event from `item` and possibly subsequent bytes through `iter`.
-pub fn parse_event<I>(item: u8, iter: &mut I) -> Result<Event, Error>
-    where I: Iterator<Item = Result<u8, Error>>
+pub fn parse_event<I>(item: u8, iter: &mut I) -> error::Result<Event>
+    where I: Iterator<Item = error::Result<u8>>
 {
-    let error = Error::new(ErrorKind::Other, "Could not parse an event");
-    match item {
+    let error = ErrorKind::UnableToParseEvent.into();
+
+    let event = match item {
         b'\x1B' => {
             // This is an escape character, leading a control sequence.
-            Ok(match iter.next() {
-                   Some(Ok(b'O')) => {
-                match iter.next() {
-                    // F1-F4
-                    Some(Ok(val @ b'P'...b'S')) => Event::Key(Key::F(1 + val - b'P')),
-                    _ => return Err(error),
+            match iter.next() {
+                Some(Ok(b'O')) => {
+                    match iter.next() {
+                        // F1-F4
+                        Some(Ok(val @ b'P'...b'S')) => Event::Key(Key::F(1 + val - b'P')),
+                        _ => return Err(error),
+                    }
                 }
+                Some(Ok(b'[')) => {
+                    // This is a CSI sequence.
+                    parse_csi(iter)?.ok_or(error)?
+                }
+                Some(Ok(c)) => {
+                    let ch = parse_utf8_char(c, iter)?;
+                    Event::Key(Key::Alt(ch))
+                }
+                Some(Err(_)) | None => return Err(error),
             }
-                   Some(Ok(b'[')) => {
-                // This is a CSI sequence.
-                parse_csi(iter).ok_or(error)?
-            }
-                   Some(Ok(c)) => {
-                let ch = parse_utf8_char(c, iter);
-                Event::Key(Key::Alt(try!(ch)))
-            }
-                   Some(Err(_)) | None => return Err(error),
-               })
         }
-        b'\n' | b'\r' => Ok(Event::Key(Key::Char('\n'))),
-        b'\t' => Ok(Event::Key(Key::Char('\t'))),
-        b'\x7F' => Ok(Event::Key(Key::Backspace)),
-        c @ b'\x01'...b'\x1A' => Ok(Event::Key(Key::Ctrl((c as u8 - 0x1 + b'a') as char))),
-        c @ b'\x1C'...b'\x1F' => Ok(Event::Key(Key::Ctrl((c as u8 - 0x1C + b'4') as char))),
-        b'\0' => Ok(Event::Key(Key::Null)),
+        b'\n' | b'\r' => Event::Key(Key::Char('\n')),
+        b'\t' => Event::Key(Key::Char('\t')),
+        b'\x7F' => Event::Key(Key::Backspace),
+        c @ b'\x01'...b'\x1A' => Event::Key(Key::Ctrl((c as u8 - 0x01 + b'a') as char)),
+        c @ b'\x1C'...b'\x1F' => Event::Key(Key::Ctrl((c as u8 - 0x1C + b'4') as char)),
+        b'\0' => Event::Key(Key::Null),
         c => {
-            Ok({
-                   let ch = parse_utf8_char(c, iter);
-                   Event::Key(Key::Char(try!(ch)))
-               })
+            let ch = parse_utf8_char(c, iter)?;
+            Event::Key(Key::Char(ch))
         }
-    }
+    };
+
+    Ok(event)
 }
 
 /// Parses a CSI sequence, just after reading ^[
 ///
-/// Returns None if an unrecognized sequence is found.
-fn parse_csi<I>(iter: &mut I) -> Option<Event>
-    where I: Iterator<Item = Result<u8, Error>>
+/// Returns Ok(None) if an unrecognized sequence is found.
+fn parse_csi<I>(iter: &mut I) -> error::Result<Option<Event>>
+    where I: Iterator<Item = error::Result<u8>>
 {
-    Some(match iter.next() {
-             Some(Ok(b'[')) => match iter.next() {
-                 Some(Ok(val @ b'A'...b'E')) => Event::Key(Key::F(1 + val - b'A')),
-                 _ => return None,
-             },
-             Some(Ok(b'D')) => Event::Key(Key::Left),
-             Some(Ok(b'C')) => Event::Key(Key::Right),
-             Some(Ok(b'A')) => Event::Key(Key::Up),
-             Some(Ok(b'B')) => Event::Key(Key::Down),
-             Some(Ok(b'H')) => Event::Key(Key::Home),
-             Some(Ok(b'F')) => Event::Key(Key::End),
-             Some(Ok(b'M')) => {
-        // X10 emulation mouse encoding: ESC [ CB Cx Cy (6 characters only).
-        let mut next = || iter.next().unwrap().unwrap();
+    let event = match iter.next() {
+        Some(Ok(b'[')) => match iter.next() {
+            Some(Ok(val @ b'A'...b'E')) => Event::Key(Key::F(1 + val - b'A')),
+            _ => return Ok(None),
+        },
+        Some(Ok(b'D')) => Event::Key(Key::Left),
+        Some(Ok(b'C')) => Event::Key(Key::Right),
+        Some(Ok(b'A')) => Event::Key(Key::Up),
+        Some(Ok(b'B')) => Event::Key(Key::Down),
+        Some(Ok(b'H')) => Event::Key(Key::Home),
+        Some(Ok(b'F')) => Event::Key(Key::End),
+        Some(Ok(b'M')) => {
+            // X10 emulation mouse encoding: ESC [ CB Cx Cy (6 characters only).
+            let cb = checked_next(iter)?? as i8 - 32;
+            // (1, 1) are the coords for upper left.
+            let cx = checked_next(iter)??.saturating_sub(32) as u16;
+            let cy = checked_next(iter)??.saturating_sub(32) as u16;
 
-        let cb = next() as i8 - 32;
-        // (1, 1) are the coords for upper left.
-        let cx = next().saturating_sub(32) as u16;
-        let cy = next().saturating_sub(32) as u16;
-        Event::Mouse(match cb & 0b11 {
-                         0 => {
-                             if cb & 0x40 != 0 {
-                                 MouseEvent::Press(MouseButton::WheelUp, cx, cy)
-                             } else {
-                                 MouseEvent::Press(MouseButton::Left, cx, cy)
-                             }
-                         }
-                         1 => {
-                             if cb & 0x40 != 0 {
-                                 MouseEvent::Press(MouseButton::WheelDown, cx, cy)
-                             } else {
-                                 MouseEvent::Press(MouseButton::Middle, cx, cy)
-                             }
-                         }
-                         2 => MouseEvent::Press(MouseButton::Right, cx, cy),
-                         3 => MouseEvent::Release(cx, cy),
-                         _ => return None,
-                     })
-    }
-             Some(Ok(b'<')) => {
-        // xterm mouse encoding:
-        // ESC [ < Cb ; Cx ; Cy (;) (M or m)
-        let mut buf = Vec::new();
-        let mut c = iter.next().unwrap().unwrap();
-        while match c {
-                  b'm' | b'M' => false,
-                  _ => true,
-              } {
+            Event::Mouse(match cb & 0b11 {
+                0b00 => {
+                    if cb & 0x40 != 0 {
+                        MouseEvent::Press(MouseButton::WheelUp, cx, cy)
+                    } else {
+                        MouseEvent::Press(MouseButton::Left, cx, cy)
+                    }
+                }
+                0b01 => {
+                    if cb & 0x40 != 0 {
+                        MouseEvent::Press(MouseButton::WheelDown, cx, cy)
+                    } else {
+                        MouseEvent::Press(MouseButton::Middle, cx, cy)
+                    }
+                }
+                0b10 => MouseEvent::Press(MouseButton::Right, cx, cy),
+                0b11 => MouseEvent::Release(cx, cy),
+                _ => return Ok(None),
+            })
+        }
+        Some(Ok(b'<')) => {
+            // xterm mouse encoding:
+            // ESC [ < Cb ; Cx ; Cy (;) (M or m)
+            let mut buf = Vec::new();
+            let mut c = checked_next(iter)??;
+            while match c {
+                b'm' | b'M' => false,
+                _ => true,
+            } {
+                buf.push(c);
+                c = checked_next(iter)??;
+            }
+
+            let str_buf = String::from_utf8(buf)?;
+            let nums = &mut str_buf.split(';');
+
+            let cb = checked_next(nums)?.parse::<u16>()?;
+            let cx = checked_next(nums)?.parse::<u16>()?;
+            let cy = checked_next(nums)?.parse::<u16>()?;
+
+            let event = match cb {
+                0...2 | 64...65 => {
+                    let button = match cb {
+                        0 => MouseButton::Left,
+                        1 => MouseButton::Middle,
+                        2 => MouseButton::Right,
+                        64 => MouseButton::WheelUp,
+                        65 => MouseButton::WheelDown,
+                        _ => unreachable!(),
+                    };
+
+                    match c {
+                        b'M' => MouseEvent::Press(button, cx, cy),
+                        b'm' => MouseEvent::Release(cx, cy),
+                        _ => return Ok(None),
+                    }
+                }
+                32 => MouseEvent::Hold(cx, cy),
+                3 => MouseEvent::Release(cx, cy),
+                _ => return Ok(None),
+            };
+
+            Event::Mouse(event)
+        }
+        Some(Ok(c @ b'0'...b'9')) => {
+            // Numbered escape code.
+            let mut buf = Vec::new();
             buf.push(c);
-            c = iter.next().unwrap().unwrap();
-        }
-        let str_buf = String::from_utf8(buf).unwrap();
-        let nums = &mut str_buf.split(';');
-
-        let cb = nums.next()
-            .unwrap()
-            .parse::<u16>()
-            .unwrap();
-        let cx = nums.next()
-            .unwrap()
-            .parse::<u16>()
-            .unwrap();
-        let cy = nums.next()
-            .unwrap()
-            .parse::<u16>()
-            .unwrap();
-
-        let event = match cb {
-            0...2 | 64...65 => {
-                let button = match cb {
-                    0 => MouseButton::Left,
-                    1 => MouseButton::Middle,
-                    2 => MouseButton::Right,
-                    64 => MouseButton::WheelUp,
-                    65 => MouseButton::WheelDown,
-                    _ => unreachable!(),
-                };
-                match c {
-                    b'M' => MouseEvent::Press(button, cx, cy),
-                    b'm' => MouseEvent::Release(cx, cy),
-                    _ => return None,
-                }
+            let mut c = checked_next(iter)??;
+            // The final byte of a CSI sequence can be in the range 64-126, so
+            // let's keep reading anything else.
+            while c < 64 || c > 126 {
+                buf.push(c);
+                c = checked_next(iter)??;
             }
-            32 => MouseEvent::Hold(cx, cy),
-            3 => MouseEvent::Release(cx, cy),
-            _ => return None,
-        };
 
-        Event::Mouse(event)
-    }
-             Some(Ok(c @ b'0'...b'9')) => {
-        // Numbered escape code.
-        let mut buf = Vec::new();
-        buf.push(c);
-        let mut c = iter.next().unwrap().unwrap();
-        // The final byte of a CSI sequence can be in the range 64-126, so
-        // let's keep reading anything else.
-        while c < 64 || c > 126 {
-            buf.push(c);
-            c = iter.next().unwrap().unwrap();
-        }
+            match c {
+                // rxvt mouse encoding:
+                // ESC [ Cb ; Cx ; Cy ; M
+                b'M' => {
+                    let str_buf = String::from_utf8(buf)?;
+                    let nums = &mut str_buf.split(';');
 
-        match c {
-            // rxvt mouse encoding:
-            // ESC [ Cb ; Cx ; Cy ; M
-            b'M' => {
-                let str_buf = String::from_utf8(buf).unwrap();
+                    let cb = checked_next(nums)?.parse::<u16>()?;
+                    let cx = checked_next(nums)?.parse::<u16>()?;
+                    let cy = checked_next(nums)?.parse::<u16>()?;
 
-                let nums: Vec<u16> = str_buf.split(';').map(|n| n.parse().unwrap()).collect();
+                    let event = match cb {
+                        32 => MouseEvent::Press(MouseButton::Left, cx, cy),
+                        33 => MouseEvent::Press(MouseButton::Middle, cx, cy),
+                        34 => MouseEvent::Press(MouseButton::Right, cx, cy),
+                        35 => MouseEvent::Release(cx, cy),
+                        64 => MouseEvent::Hold(cx, cy),
+                        96 | 97 => MouseEvent::Press(MouseButton::WheelUp, cx, cy),
+                        _ => return Ok(None),
+                    };
 
-                let cb = nums[0];
-                let cx = nums[1];
-                let cy = nums[2];
+                    Event::Mouse(event)
+                }
+                // Special key code.
+                b'~' => {
+                    let str_buf = String::from_utf8(buf)?;
 
-                let event = match cb {
-                    32 => MouseEvent::Press(MouseButton::Left, cx, cy),
-                    33 => MouseEvent::Press(MouseButton::Middle, cx, cy),
-                    34 => MouseEvent::Press(MouseButton::Right, cx, cy),
-                    35 => MouseEvent::Release(cx, cy),
-                    64 => MouseEvent::Hold(cx, cy),
-                    96 | 97 => MouseEvent::Press(MouseButton::WheelUp, cx, cy),
-                    _ => return None,
-                };
+                    // This CSI sequence can be a list of semicolon-separated
+                    // numbers.
+                    let nums = &mut str_buf.split(';');
 
-                Event::Mouse(event)
+                    let c = nums.next();
+                    if c.is_none() {
+                        return Ok(None);
+                    }
+
+                    // TODO: handle multiple values for key modififiers (ex: values
+                    // [3, 2] means Shift+Delete)
+                    if nums.next().is_some() {
+                        return Ok(None);
+                    }
+
+                    match c.unwrap().parse::<u8>()? {
+                        1 | 7 => Event::Key(Key::Home),
+                        2 => Event::Key(Key::Insert),
+                        3 => Event::Key(Key::Delete),
+                        4 | 8 => Event::Key(Key::End),
+                        5 => Event::Key(Key::PageUp),
+                        6 => Event::Key(Key::PageDown),
+                        v @ 11...15 => Event::Key(Key::F(v - 10)),
+                        v @ 17...21 => Event::Key(Key::F(v - 11)),
+                        v @ 23...24 => Event::Key(Key::F(v - 12)),
+                        _ => return Ok(None),
+                    }
+                }
+                _ => return Ok(None),
             }
-            // Special key code.
-            b'~' => {
-                let str_buf = String::from_utf8(buf).unwrap();
-
-                // This CSI sequence can be a list of semicolon-separated
-                // numbers.
-                let nums: Vec<u8> = str_buf.split(';').map(|n| n.parse().unwrap()).collect();
-
-                if nums.is_empty() {
-                    return None;
-                }
-
-                // TODO: handle multiple values for key modififiers (ex: values
-                // [3, 2] means Shift+Delete)
-                if nums.len() > 1 {
-                    return None;
-                }
-
-                match nums[0] {
-                    1 | 7 => Event::Key(Key::Home),
-                    2 => Event::Key(Key::Insert),
-                    3 => Event::Key(Key::Delete),
-                    4 | 8 => Event::Key(Key::End),
-                    5 => Event::Key(Key::PageUp),
-                    6 => Event::Key(Key::PageDown),
-                    v @ 11...15 => Event::Key(Key::F(v - 10)),
-                    v @ 17...21 => Event::Key(Key::F(v - 11)),
-                    v @ 23...24 => Event::Key(Key::F(v - 12)),
-                    _ => return None,
-                }
-            }
-            _ => return None,
         }
-    }
-             _ => return None,
-         })
+        _ => return Ok(None),
+    };
 
+    Ok(Some(event))
 }
 
 /// Parse `c` as either a single byte ASCII char or a variable size UTF-8 char.
-fn parse_utf8_char<I>(c: u8, iter: &mut I) -> Result<char, Error>
-    where I: Iterator<Item = Result<u8, Error>>
+fn parse_utf8_char<I>(c: u8, iter: &mut I) -> error::Result<char>
+    where I: Iterator<Item = error::Result<u8>>
 {
-    let error = Err(Error::new(ErrorKind::Other, "Input character is not valid UTF-8"));
+    let error = ErrorKind::InvalidUtf8InputChar.into();
+
     if c.is_ascii() {
         Ok(c as char)
     } else {
@@ -326,17 +322,24 @@ fn parse_utf8_char<I>(c: u8, iter: &mut I) -> Result<char, Error>
                 Some(Ok(next)) => {
                     bytes.push(next);
                     if let Ok(st) = str::from_utf8(bytes) {
-                        return Ok(st.chars().next().unwrap());
+                        return st.chars().next().ok_or(ErrorKind::UnexpectedIterEnd.into());
                     }
                     if bytes.len() >= 4 {
-                        return error;
+                        return Err(error);
                     }
                 }
-                _ => return error,
+                _ => return Err(error),
             }
         }
     }
 }
+
+fn checked_next<T, I>(iterator: &mut I) -> error::Result<T>
+    where I: Iterator<Item = T>
+{
+    iterator.next().ok_or(ErrorKind::UnexpectedIterEnd.into())
+}
+
 
 #[cfg(test)]
 #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,3 +45,4 @@ pub mod raw;
 pub mod screen;
 pub mod scroll;
 pub mod style;
+mod utils;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,6 +26,8 @@ extern crate syscall;
 mod async;
 pub use async::{AsyncReader, async_stdin};
 
+mod error;
+
 mod size;
 pub use size::terminal_size;
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,0 +1,13 @@
+use error::{self, ErrorKind};
+
+
+/// Errors if the iterator returns `None`.
+pub fn checked_next<T, I>(iterator: &mut I) -> error::Result<T>
+    where I: Iterator<Item = T>
+{
+    iterator.next().ok_or(ErrorKind::UnexpectedIterEnd.into())
+}
+
+pub fn checked_rfind_bracket(s: &str) -> error::Result<usize> {
+    s.rfind('[').ok_or(ErrorKind::NoCursorBracket.into())
+}


### PR DESCRIPTION
Things have done to achieve that:
- Introducing an `error_chain`-ish custom error type, convertable from all other ones used in src/event.rs and src/cursor.rs.
- Replacing `.unwrap()`s in src/event.rs and src/cursor.rs by explicit error return values.
- Modifying public interfaces which is mentioned below.
- Refactoring and fixing formatting.

Changes that can be considered as regressions:
- Using custom error type instead of `std::io::Error` _may_ add memory and likely but little CPU overhead, though compiler could possibly pull some null-pointer optimizations to completely remove the said overhead. This is also useful for end-users that want to filter the specific error which is hard with `io::Error::new(/* whatever io::ErrorKind variant here */, "custom error message")`.
- Breaking changes in the public `cursor::DetectCursorPos` trait: `cursor_pos` method now returns `error::Result<(u16, u16)>` instead of `io::Result<(u16, u16)>`.

Possible improvement ideas, their pros and cons:
- Switch completely to `error_chain` - this introduces the `backtrace` dependency which may not be suitable for platforms that don't support it, and as a result, makes the `error::Error` type consume more memory - which was the primary reason to not to use that crate from the beginning. On the other hand, improved maintainability and readability.
- If the breaking change above is accepted, use `error::Error` and `error::Result` throughout the crate, not just in `src/event.rs` and `src/cursor.rs`, for better interoperability and consistency (if make a breaking change anyway, do it correctly).
  If not, then convert everything back to `io::Error` and `io::Result` which is fine, but in this case custom errors [_do_ need heap allocation](https://doc.rust-lang.org/std/io/struct.Error.html#method.new). And of course, no plans to go back to `.unwrap()`s (the fewer unexpected panics, the better).