### PR TITLE
Fix raw mode when stdin is not a terminal

### DIFF
--- a/src/input.rs
+++ b/src/input.rs
@@ -120,9 +120,11 @@ pub trait TermRead {
     ///
     /// EOT and ETX will abort the prompt, returning `None`. Newline or carriage return will
     /// complete the input.
-    fn read_passwd<W: Write>(&mut self, writer: &mut W) -> io::Result<Option<String>> {
-        let _raw = try!(writer.into_raw_mode());
-        self.read_line()
+    fn read_passwd<W: IntoRawMode>(&mut self, writer: &mut W) -> io::Result<Option<String>> {
+        let raw = try!(writer.into_raw_mode());
+        let res = self.read_line();
+        drop(raw);
+        res
     }
 }
 

--- a/src/sys/redox/attr.rs
+++ b/src/sys/redox/attr.rs
@@ -1,13 +1,14 @@
 use std::io;
+use std::os::unix::io::RawFd;
 
 use super::{cvt, syscall, Termios};
 
-pub fn get_terminal_attr() -> io::Result<Termios> {
+pub fn get_terminal_attr(fd: RawFd) -> io::Result<Termios> {
     let mut termios = Termios::default();
 
-    let fd = cvt(syscall::dup(0, b"termios"))?;
-    let res = cvt(syscall::read(fd, &mut termios));
-    let _ = syscall::close(fd);
+    let tfd = cvt(syscall::dup(fd, b"termios"))?;
+    let res = cvt(syscall::read(tfd, &mut termios));
+    let _ = syscall::close(tfd);
 
     if res? == termios.len() {
         Ok(termios)
@@ -16,10 +17,10 @@ pub fn get_terminal_attr() -> io::Result<Termios> {
     }
 }
 
-pub fn set_terminal_attr(termios: &Termios) -> io::Result<()> {
-    let fd = cvt(syscall::dup(0, b"termios"))?;
-    let res = cvt(syscall::write(fd, termios));
-    let _ = syscall::close(fd);
+pub fn set_terminal_attr(fd: RawFd, termios: &Termios) -> io::Result<()> {
+    let tfd = cvt(syscall::dup(fd, b"termios"))?;
+    let res = cvt(syscall::write(tfd, termios));
+    let _ = syscall::close(tfd);
 
     if res? == termios.len() {
         Ok(())

--- a/src/sys/unix/attr.rs
+++ b/src/sys/unix/attr.rs
@@ -1,24 +1,25 @@
 use std::{io, mem};
+use std::os::unix::io::RawFd;
 
 use super::{cvt, Termios};
 use super::libc::c_int;
 
-pub fn get_terminal_attr() -> io::Result<Termios> {
+pub fn get_terminal_attr(fd: RawFd) -> io::Result<Termios> {
     extern "C" {
         pub fn tcgetattr(fd: c_int, termptr: *mut Termios) -> c_int;
     }
     unsafe {
         let mut termios = mem::zeroed();
-        cvt(tcgetattr(0, &mut termios))?;
+        cvt(tcgetattr(fd, &mut termios))?;
         Ok(termios)
     }
 }
 
-pub fn set_terminal_attr(termios: &Termios) -> io::Result<()> {
+pub fn set_terminal_attr(fd: RawFd, termios: &Termios) -> io::Result<()> {
     extern "C" {
         pub fn tcsetattr(fd: c_int, opt: c_int, termptr: *const Termios) -> c_int;
     }
-    cvt(unsafe { tcsetattr(0, 0, termios) }).and(Ok(()))
+    cvt(unsafe { tcsetattr(fd, 0, termios) }).and(Ok(()))
 }
 
 pub fn raw_terminal_attr(termios: &mut Termios) {


### PR DESCRIPTION
This allows raw mode to be used even when stdin has been changed, for example:

```
ps ax | less
```