### PR TITLE
Add support for capturing `Key::Esc`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,11 @@ license = "MIT"
 keywords = ["tty", "color", "terminal", "password", "tui"]
 exclude = ["target", "CHANGELOG.md", "image.png", "Cargo.lock"]
 
+[dependencies]
+serde = "1.0"
+serde_json = "1.0"
+serde_derive = "1.0"
+
 [target.'cfg(not(target_os = "redox"))'.dependencies]
 libc = "0.2.8"
 

--- a/examples/keys.rs
+++ b/examples/keys.rs
@@ -1,4 +1,5 @@
 extern crate termion;
+extern crate serde_json;
 
 use termion::event::Key;
 use termion::input::TermRead;
@@ -9,22 +10,35 @@ fn main() {
     let stdin = stdin();
     let mut stdout = stdout().into_raw_mode().unwrap();
 
-    write!(stdout,
-           "{}{}q to exit. Type stuff, use alt, and so on.{}",
-           termion::clear::All,
-           termion::cursor::Goto(1, 1),
-           termion::cursor::Hide)
-            .unwrap();
+    write!(
+        stdout,
+        "{}{}q to exit. Type stuff, use alt, and so on.{}",
+        termion::clear::All,
+        termion::cursor::Goto(1, 1),
+        termion::cursor::Hide
+    ).unwrap();
     stdout.flush().unwrap();
 
     for c in stdin.keys() {
-        write!(stdout,
-               "{}{}",
-               termion::cursor::Goto(1, 1),
-               termion::clear::CurrentLine)
-                .unwrap();
+        write!(
+            stdout,
+            "{}{}",
+            termion::cursor::Goto(1, 1),
+            termion::clear::CurrentLine
+        ).unwrap();
 
-        match c.unwrap() {
+        let chr = c.unwrap();
+
+        match serde_json::to_string(&chr) {
+            Ok(json) => {
+                println!("{}", json);
+            }
+            Err(err) => {
+                println!("{}", err);
+            }
+        }
+
+        match chr {
             Key::Char('q') => break,
             Key::Char(c) => println!("{}", c),
             Key::Alt(c) => println!("^{}", c),

--- a/src/async.rs
+++ b/src/async.rs
@@ -18,10 +18,10 @@ pub fn async_stdin() -> AsyncReader {
     let (send, recv) = mpsc::channel();
 
     thread::spawn(move || for i in get_tty().unwrap().bytes() {
-                      if send.send(i).is_err() {
-                          return;
-                      }
-                  });
+        if send.send(i).is_err() {
+            return;
+        }
+    });
 
     AsyncReader { recv: recv }
 }

--- a/src/color.rs
+++ b/src/color.rs
@@ -83,15 +83,21 @@ pub struct AnsiValue(pub u8);
 impl AnsiValue {
     /// 216-color (r, g, b ≤ 5) RGB.
     pub fn rgb(r: u8, g: u8, b: u8) -> AnsiValue {
-        debug_assert!(r <= 5,
-                      "Red color fragment (r = {}) is out of bound. Make sure r ≤ 5.",
-                      r);
-        debug_assert!(g <= 5,
-                      "Green color fragment (g = {}) is out of bound. Make sure g ≤ 5.",
-                      g);
-        debug_assert!(b <= 5,
-                      "Blue color fragment (b = {}) is out of bound. Make sure b ≤ 5.",
-                      b);
+        debug_assert!(
+            r <= 5,
+            "Red color fragment (r = {}) is out of bound. Make sure r ≤ 5.",
+            r
+        );
+        debug_assert!(
+            g <= 5,
+            "Green color fragment (g = {}) is out of bound. Make sure g ≤ 5.",
+            g
+        );
+        debug_assert!(
+            b <= 5,
+            "Blue color fragment (b = {}) is out of bound. Make sure b ≤ 5.",
+            b
+        );
 
         AnsiValue(16 + 36 * r + 6 * g + b)
     }
@@ -101,10 +107,12 @@ impl AnsiValue {
     /// There are 24 shades of gray.
     pub fn grayscale(shade: u8) -> AnsiValue {
         // Unfortunately, there are a little less than fifty shades.
-        debug_assert!(shade < 24,
-                      "Grayscale out of bound (shade = {}). There are only 24 shades of \
+        debug_assert!(
+            shade < 24,
+            "Grayscale out of bound (shade = {}). There are only 24 shades of \
                       gray.",
-                      shade);
+            shade
+        );
 
         AnsiValue(0xE8 + shade)
     }
@@ -205,21 +213,25 @@ impl<W: Write> DetectColors for W {
         } else {
             // OSC 4 is not supported, trust TERM contents.
             Ok(match env::var_os("TERM") {
-                   Some(val) => {
-                       if val.to_str().unwrap_or("").contains("256color") {
-                           256
-                       } else {
-                           8
-                       }
-                   }
-                   None => 8,
-               })
+                Some(val) => {
+                    if val.to_str().unwrap_or("").contains("256color") {
+                        256
+                    } else {
+                        8
+                    }
+                }
+                None => 8,
+            })
         }
     }
 }
 
 /// Detect a color using OSC 4.
-fn detect_color(stdout: &mut Write, stdin: &mut Read, color: u16) -> io::Result<bool> {
+fn detect_color(
+    stdout: &mut Write,
+    stdin: &mut Read,
+    color: u16,
+) -> io::Result<bool> {
     // Is the color available?
     // Use `ESC ] 4 ; color ; ? BEL`.
     write!(stdout, "\x1B]4;{};?\x07", color)?;

--- a/src/cursor.rs
+++ b/src/cursor.rs
@@ -115,7 +115,10 @@ impl<W: Write> DetectCursorPos for W {
         }
 
         if read_chars.len() == 0 {
-            return Err(Error::new(ErrorKind::Other, "Cursor position detection timed out."));
+            return Err(Error::new(
+                ErrorKind::Other,
+                "Cursor position detection timed out.",
+            ));
         }
 
         // The answer will look like `ESC [ Cy ; Cx R`.
@@ -126,14 +129,8 @@ impl<W: Write> DetectCursorPos for W {
         let coords: String = read_str.chars().skip(beg + 1).collect();
         let mut nums = coords.split(';');
 
-        let cy = nums.next()
-            .unwrap()
-            .parse::<u16>()
-            .unwrap();
-        let cx = nums.next()
-            .unwrap()
-            .parse::<u16>()
-            .unwrap();
+        let cy = nums.next().unwrap().parse::<u16>().unwrap();
+        let cx = nums.next().unwrap().parse::<u16>().unwrap();
 
         Ok((cx, cy))
     }

--- a/src/event.rs
+++ b/src/event.rs
@@ -5,7 +5,8 @@ use std::ascii::AsciiExt;
 use std::str;
 
 /// An event reported by the terminal.
-#[derive(PartialOrd, Ord, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Serialize, Deserialize, PartialOrd, Ord, Debug, Clone, PartialEq, Eq,
+         Hash)]
 pub enum Event {
     /// A key press.
     Key(Key),
@@ -16,7 +17,8 @@ pub enum Event {
 }
 
 /// A mouse related event.
-#[derive(PartialOrd, Ord, Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[derive(Serialize, Deserialize, PartialOrd, Ord, Debug, Copy, Clone,
+         PartialEq, Eq, Hash)]
 pub enum MouseEvent {
     /// A mouse button was pressed.
     ///
@@ -33,7 +35,8 @@ pub enum MouseEvent {
 }
 
 /// A mouse button.
-#[derive(PartialOrd, Ord, Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[derive(Serialize, Deserialize, PartialOrd, Ord, Debug, Copy, Clone,
+         PartialEq, Eq, Hash)]
 pub enum MouseButton {
     /// The left mouse button.
     Left,
@@ -52,7 +55,8 @@ pub enum MouseButton {
 }
 
 /// A key.
-#[derive(PartialOrd, Ord, Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[derive(Serialize, Deserialize, PartialOrd, Ord, Debug, Copy, Clone,
+         PartialEq, Eq, Hash)]
 pub enum Key {
     /// Backspace.
     Backspace,
@@ -86,7 +90,8 @@ pub enum Key {
     Alt(char),
     /// Ctrl modified character.
     ///
-    /// Note that certain keys may not be modifiable with `ctrl`, due to limitations of terminals.
+    /// Note that certain keys may not be modifiable with `ctrl`, due to
+    /// limitations of terminals.
     Ctrl(char),
     /// Null byte.
     Null,
@@ -108,7 +113,9 @@ where
         b'\n' | b'\r' => Ok(Event::Key(Key::Char('\n'))),
         b'\t' => Ok(Event::Key(Key::Char('\t'))),
         b'\x7F' => Ok(Event::Key(Key::Backspace)),
-        c @ b'\x01'...b'\x1F' => Ok(Event::Key(Key::Ctrl((c as u8 - 0x1 + b'a') as char))),
+        c @ b'\x01'...b'\x1F' => Ok(Event::Key(
+            Key::Ctrl((c as u8 - 0x1 + b'a') as char),
+        )),
         b'\0' => Ok(Event::Key(Key::Null)),
         c => {
             Ok({
@@ -127,7 +134,9 @@ where
         Some(Ok(b'O')) => {
             match iter.next() {
                 // F1-F4
-                Some(Ok(val @ b'P'...b'S')) => Ok(Event::Key(Key::F(1 + val - b'P'))),
+                Some(Ok(val @ b'P'...b'S')) => Ok(Event::Key(
+                    Key::F(1 + val - b'P'),
+                )),
                 Some(Err(e)) => Err(e),
                 Some(Ok(_)) | None => Err(Error::new(
                     ErrorKind::Other,
@@ -160,7 +169,9 @@ where
     Ok(match iter.next() {
         Some(Ok(b'[')) => {
             return match iter.next() {
-                Some(Ok(val @ b'A'...b'E')) => Ok(Event::Key(Key::F(1 + val - b'A'))),
+                Some(Ok(val @ b'A'...b'E')) => Ok(Event::Key(
+                    Key::F(1 + val - b'A'),
+                )),
                 _ => Err(Error::new(
                     ErrorKind::Other,
                     "Input character is not valid UTF-8",
@@ -192,7 +203,9 @@ where
             ))
         }
         _ => {
-            return Err(Error::new(ErrorKind::Other, "Input is not a valid CSI"));
+            return Err(
+                Error::new(ErrorKind::Other, "Input is not a valid CSI"),
+            );
         }
     })
 }
@@ -218,7 +231,8 @@ where
         b'M' => {
             let str_buf = String::from_utf8(buf).unwrap();
 
-            let nums: Vec<u16> = str_buf.split(';').map(|n| n.parse().unwrap()).collect();
+            let nums: Vec<u16> =
+                str_buf.split(';').map(|n| n.parse().unwrap()).collect();
 
             let cb = nums[0];
             let cx = nums[1];
@@ -242,7 +256,8 @@ where
 
             // This CSI sequence can be a list of semicolon-separated
             // numbers.
-            let nums: Vec<u8> = str_buf.split(';').map(|n| n.parse().unwrap()).collect();
+            let nums: Vec<u8> =
+                str_buf.split(';').map(|n| n.parse().unwrap()).collect();
 
             if nums.is_empty() {
                 return None;

--- a/src/event.rs
+++ b/src/event.rs
@@ -98,7 +98,6 @@ pub enum Key {
 }
 
 /// Parse an Event from `item` and possibly subsequent bytes through `iter`.
-/// TODO It isn't clear if a single Esc keystroke will be properly captured.
 pub fn parse_event<I>(item: u8, iter: &mut I) -> Result<Event, Error>
 where
     I: Iterator<Item = Result<u8, Error>>,
@@ -384,13 +383,24 @@ where
 }
 
 #[cfg(test)]
-#[test]
-fn test_parse_utf8() {
-    let st = "abcéŷ¤£€ù%323";
-    let ref mut bytes = st.bytes().map(|x| Ok(x));
-    let chars = st.chars();
-    for c in chars {
+mod test {
+    use super::*;
+
+    #[test]
+    fn parse_utf8() {
+        let st = "abcéŷ¤£€ù%323";
+        let ref mut bytes = st.bytes().map(|x| Ok(x));
+        let chars = st.chars();
+        for c in chars {
+            let b = bytes.next().unwrap().unwrap();
+            assert_eq!(c, parse_utf8_char(b, bytes).unwrap());
+        }
+    }
+    #[test]
+    fn parse_esc() {
+        let st = "";
+        let ref mut bytes = st.bytes().map(|x| Ok(x));
         let b = bytes.next().unwrap().unwrap();
-        assert!(c == parse_utf8_char(b, bytes).unwrap());
+        assert_eq!(Event::Key(Key::Esc), parse_event(b, bytes).unwrap());
     }
 }

--- a/src/event.rs
+++ b/src/event.rs
@@ -98,39 +98,55 @@ pub enum Key {
     __IsNotComplete,
 }
 
+// For reference:
+// http://vimhelp.appspot.com/vim_faq.txt.html#faq-20.5
+// \x00 = ^@
+// \x01 = ^A = <C-A>
+// ...
+// \x09 = ^I = <C-I> = <Tab>
+// ...
+// \x0D = ^M = <C-M> = <C-Enter>
+// ...
+// \x1A = ^Z = <C-Z>
+// \x1B = ^[ = <C-[> = <C-3> = Esc
+// \x1C = ^\ = <C-\> = <C-4>
+// \x1D = ^] = <C-]> = <C-5>
+// \x1E = ^^ = <C-^> = <C-6>
+// \x1F = ^_ = <C-/> = <C-7> = <C-_>
+// \x7F = ^? = <C-?> = <C-8> = <C-Delete> = <C-Bksp>
 fn quantify_key(key: &Key) -> u32 {
-    // TODO: Derive the proper formula for Ctrl and Alt.
-    const CTRL_PREFIX: u32 = 0x10000000u32;
-    const ALT_PREFIX:  u32 = 0x20000000u32;
-    match key {
-        &Key::Null      => 0x00000000u32,
-        &Key::Backspace => 0x00000008u32,
-        &Key::Esc       => 0x0000001Bu32,
-        &Key::Delete    => 0x0000007Fu32,
-        &Key::Insert    => 0x40000049u32,
-        &Key::Home      => 0x4000004Au32,
-        &Key::PageUp    => 0x4000004Bu32,
-        &Key::End       => 0x4000004Du32,
-        &Key::PageDown  => 0x4000004Eu32,
-        &Key::Right     => 0x4000004Fu32,
-        &Key::Left      => 0x40000050u32,
-        &Key::Down      => 0x40000051u32,
-        &Key::Up        => 0x40000052u32,
-        &Key::F(b) => match b {
-                    1 ... 12 => (b as u32) + 0x40000039u32,
-                    13 ... 24 => (b as u32) + 0x4000005au32,
-                    _ => panic!()
-                },
-        &Key::Char(c) => c as u32,
-        &Key::Alt(c) => c as u32 + ALT_PREFIX,
-        &Key::Ctrl(c) => c as u32 + CTRL_PREFIX,
-        &Key::__IsNotComplete => panic!(),
+    // http://vimhelp.appspot.com/intro.txt.html#key-codes
+    match *key {
+        Key::Null => 0x00000000u32,
+        Key::Backspace => 0x00000008u32,
+        Key::Esc => 0x0000001Bu32,
+        Key::Delete => 0x0000007Fu32,
+        Key::Insert => 0x40000049u32,
+        Key::Home => 0x4000004Au32,
+        Key::PageUp => 0x4000004Bu32,
+        Key::End => 0x4000004Du32,
+        Key::PageDown => 0x4000004Eu32,
+        Key::Right => 0x4000004Fu32,
+        Key::Left => 0x40000050u32,
+        Key::Down => 0x40000051u32,
+        Key::Up => 0x40000052u32,
+        Key::F(b) => {
+            match b {
+                1...12 => (b as u32) + 0x40000039u32,
+                13...24 => (b as u32) + 0x4000005Au32,
+                _ => 0x00,
+            }
+        }
+        Key::Char(c) => c as u32,
+        Key::Alt(c) => (c as u32) | 0x10,
+        Key::Ctrl(c) => ((c as u32) - ('A' as u32) + 1),
+        Key::__IsNotComplete => 0x00,
     }
 }
 
 impl PartialOrd for Key {
     fn partial_cmp(&self, other: &Key) -> Option<Ordering> {
-        Some(quantify_key(self).cmp(&quantify_key(other)))
+        Some(self.cmp(other))
     }
 }
 
@@ -141,223 +157,268 @@ impl Ord for Key {
 }
 
 /// Parse an Event from `item` and possibly subsequent bytes through `iter`.
+/// TODO It isn't clear if a single Esc keystroke will be properly captured.
 pub fn parse_event<I>(item: u8, iter: &mut I) -> Result<Event, Error>
-    where I: Iterator<Item = Result<u8, Error>>
+where
+    I: Iterator<Item = Result<u8, Error>>,
 {
-    let error = Error::new(ErrorKind::Other, "Could not parse an event");
     match item {
-        b'\x1B' => {
-            // This is an escape character, leading a control sequence.
-            Ok(match iter.next() {
-                   Some(Ok(b'O')) => {
-                match iter.next() {
-                    // F1-F4
-                    Some(Ok(val @ b'P'...b'S')) => Event::Key(Key::F(1 + val - b'P')),
-                    _ => return Err(error),
-                }
-            }
-                   Some(Ok(b'[')) => {
-                // This is a CSI sequence.
-                parse_csi(iter).ok_or(error)?
-            }
-                   Some(Ok(c)) => {
-                let ch = parse_utf8_char(c, iter);
-                Event::Key(Key::Alt(try!(ch)))
-            }
-                   Some(Err(_)) | None => return Err(error),
-               })
-        }
+        // This is an escape character, leading a control sequence.
+        b'\x1B' => parse_escape(iter),
         b'\n' | b'\r' => Ok(Event::Key(Key::Char('\n'))),
         b'\t' => Ok(Event::Key(Key::Char('\t'))),
         b'\x7F' => Ok(Event::Key(Key::Backspace)),
-        c @ b'\x01'...b'\x1A' => Ok(Event::Key(Key::Ctrl((c as u8 - 0x1 + b'a') as char))),
-        c @ b'\x1C'...b'\x1F' => Ok(Event::Key(Key::Ctrl((c as u8 - 0x1C + b'4') as char))),
+        c @ b'\x01'...b'\x1F' => Ok(Event::Key(Key::Ctrl((c as u8 - 0x1 + b'a') as char))),
         b'\0' => Ok(Event::Key(Key::Null)),
         c => {
             Ok({
-                   let ch = parse_utf8_char(c, iter);
-                   Event::Key(Key::Char(try!(ch)))
-               })
+                let ch = parse_utf8_char(c, iter);
+                Event::Key(Key::Char(try!(ch)))
+            })
         }
+    }
+}
+
+fn parse_escape<I>(iter: &mut I) -> Result<Event, Error>
+where
+    I: Iterator<Item = Result<u8, Error>>,
+{
+    match iter.next() {
+        Some(Ok(b'O')) => {
+            match iter.next() {
+                // F1-F4
+                Some(Ok(val @ b'P'...b'S')) => Ok(Event::Key(Key::F(1 + val - b'P'))),
+                Some(Err(e)) => Err(e),
+                Some(Ok(_)) | None => Err(Error::new(
+                    ErrorKind::Other,
+                    "Input character is not a valid Function key",
+                )),
+            }
+        }
+        Some(Ok(b'[')) => {
+            // This is a CSI sequence.
+            parse_csi(iter)
+        }
+        Some(Ok(c)) => {
+            match parse_utf8_char(c, iter) {
+                Ok(x) => Ok(Event::Key(Key::Alt(x))),
+                Err(e) => Err(e),
+            }
+        }
+        Some(Err(e)) => Err(e),
+        None => Ok(Event::Key(Key::Esc)),
     }
 }
 
 /// Parses a CSI sequence, just after reading ^[
 ///
 /// Returns None if an unrecognized sequence is found.
-fn parse_csi<I>(iter: &mut I) -> Option<Event>
-    where I: Iterator<Item = Result<u8, Error>>
+fn parse_csi<I>(iter: &mut I) -> Result<Event, Error>
+where
+    I: Iterator<Item = Result<u8, Error>>,
 {
-    Some(match iter.next() {
-             Some(Ok(b'[')) => match iter.next() {
-                 Some(Ok(val @ b'A'...b'E')) => Event::Key(Key::F(1 + val - b'A')),
-                 _ => return None,
-             },
-             Some(Ok(b'D')) => Event::Key(Key::Left),
-             Some(Ok(b'C')) => Event::Key(Key::Right),
-             Some(Ok(b'A')) => Event::Key(Key::Up),
-             Some(Ok(b'B')) => Event::Key(Key::Down),
-             Some(Ok(b'H')) => Event::Key(Key::Home),
-             Some(Ok(b'F')) => Event::Key(Key::End),
-             Some(Ok(b'M')) => {
-        // X10 emulation mouse encoding: ESC [ CB Cx Cy (6 characters only).
-        let mut next = || iter.next().unwrap().unwrap();
-
-        let cb = next() as i8 - 32;
-        // (1, 1) are the coords for upper left.
-        let cx = next().saturating_sub(32) as u16;
-        let cy = next().saturating_sub(32) as u16;
-        Event::Mouse(match cb & 0b11 {
-                         0 => {
-                             if cb & 0x40 != 0 {
-                                 MouseEvent::Press(MouseButton::WheelUp, cx, cy)
-                             } else {
-                                 MouseEvent::Press(MouseButton::Left, cx, cy)
-                             }
-                         }
-                         1 => {
-                             if cb & 0x40 != 0 {
-                                 MouseEvent::Press(MouseButton::WheelDown, cx, cy)
-                             } else {
-                                 MouseEvent::Press(MouseButton::Middle, cx, cy)
-                             }
-                         }
-                         2 => MouseEvent::Press(MouseButton::Right, cx, cy),
-                         3 => MouseEvent::Release(cx, cy),
-                         _ => return None,
-                     })
-    }
-             Some(Ok(b'<')) => {
-        // xterm mouse encoding:
-        // ESC [ < Cb ; Cx ; Cy (;) (M or m)
-        let mut buf = Vec::new();
-        let mut c = iter.next().unwrap().unwrap();
-        while match c {
-                  b'm' | b'M' => false,
-                  _ => true,
-              } {
-            buf.push(c);
-            c = iter.next().unwrap().unwrap();
-        }
-        let str_buf = String::from_utf8(buf).unwrap();
-        let nums = &mut str_buf.split(';');
-
-        let cb = nums.next()
-            .unwrap()
-            .parse::<u16>()
-            .unwrap();
-        let cx = nums.next()
-            .unwrap()
-            .parse::<u16>()
-            .unwrap();
-        let cy = nums.next()
-            .unwrap()
-            .parse::<u16>()
-            .unwrap();
-
-        let event = match cb {
-            0...2 | 64...65 => {
-                let button = match cb {
-                    0 => MouseButton::Left,
-                    1 => MouseButton::Middle,
-                    2 => MouseButton::Right,
-                    64 => MouseButton::WheelUp,
-                    65 => MouseButton::WheelDown,
-                    _ => unreachable!(),
-                };
-                match c {
-                    b'M' => MouseEvent::Press(button, cx, cy),
-                    b'm' => MouseEvent::Release(cx, cy),
-                    _ => return None,
-                }
+    Ok(match iter.next() {
+        Some(Ok(b'[')) => {
+            return match iter.next() {
+                Some(Ok(val @ b'A'...b'E')) => Ok(Event::Key(Key::F(1 + val - b'A'))),
+                _ => Err(Error::new(
+                    ErrorKind::Other,
+                    "Input character is not valid UTF-8",
+                )),
             }
-            32 => MouseEvent::Hold(cx, cy),
-            3 => MouseEvent::Release(cx, cy),
-            _ => return None,
-        };
+        }
+        Some(Ok(b'D')) => Event::Key(Key::Left),
+        Some(Ok(b'C')) => Event::Key(Key::Right),
+        Some(Ok(b'A')) => Event::Key(Key::Up),
+        Some(Ok(b'B')) => Event::Key(Key::Down),
+        Some(Ok(b'H')) => Event::Key(Key::Home),
+        Some(Ok(b'F')) => Event::Key(Key::End),
+        Some(Ok(b'M')) => {
+            return parse_x10_mouse(iter).ok_or(Error::new(
+                ErrorKind::Other,
+                "Input is not a valid x10 mouse sequence",
+            ))
+        }
+        Some(Ok(b'<')) => {
+            return parse_xterm_mouse(iter).ok_or(Error::new(
+                ErrorKind::Other,
+                "Input is not a valid xterm mouse sequence",
+            ))
+        }
+        Some(Ok(c @ b'0'...b'9')) => {
+            return parse_numbered_escape_code(c, iter).ok_or(Error::new(
+                ErrorKind::Other,
+                "Input is not a valid numbered escape code",
+            ))
+        }
+        _ => {
+            return Err(Error::new(ErrorKind::Other, "Input is not a valid CSI"));
+        }
+    })
+}
 
-        Event::Mouse(event)
-    }
-             Some(Ok(c @ b'0'...b'9')) => {
-        // Numbered escape code.
-        let mut buf = Vec::new();
+fn parse_numbered_escape_code<I>(c: u8, iter: &mut I) -> Option<Event>
+where
+    I: Iterator<Item = Result<u8, Error>>,
+{
+    // Numbered escape code.
+    let mut buf = Vec::new();
+    buf.push(c);
+    let mut c = iter.next().unwrap().unwrap();
+    // The final byte of a CSI sequence can be in the range 64-126, so
+    // let's keep reading anything else.
+    while c < 64 || c > 126 {
         buf.push(c);
-        let mut c = iter.next().unwrap().unwrap();
-        // The final byte of a CSI sequence can be in the range 64-126, so
-        // let's keep reading anything else.
-        while c < 64 || c > 126 {
-            buf.push(c);
-            c = iter.next().unwrap().unwrap();
-        }
-
-        match c {
-            // rxvt mouse encoding:
-            // ESC [ Cb ; Cx ; Cy ; M
-            b'M' => {
-                let str_buf = String::from_utf8(buf).unwrap();
-
-                let nums: Vec<u16> = str_buf.split(';').map(|n| n.parse().unwrap()).collect();
-
-                let cb = nums[0];
-                let cx = nums[1];
-                let cy = nums[2];
-
-                let event = match cb {
-                    32 => MouseEvent::Press(MouseButton::Left, cx, cy),
-                    33 => MouseEvent::Press(MouseButton::Middle, cx, cy),
-                    34 => MouseEvent::Press(MouseButton::Right, cx, cy),
-                    35 => MouseEvent::Release(cx, cy),
-                    64 => MouseEvent::Hold(cx, cy),
-                    96 | 97 => MouseEvent::Press(MouseButton::WheelUp, cx, cy),
-                    _ => return None,
-                };
-
-                Event::Mouse(event)
-            }
-            // Special key code.
-            b'~' => {
-                let str_buf = String::from_utf8(buf).unwrap();
-
-                // This CSI sequence can be a list of semicolon-separated
-                // numbers.
-                let nums: Vec<u8> = str_buf.split(';').map(|n| n.parse().unwrap()).collect();
-
-                if nums.is_empty() {
-                    return None;
-                }
-
-                // TODO: handle multiple values for key modififiers (ex: values
-                // [3, 2] means Shift+Delete)
-                if nums.len() > 1 {
-                    return None;
-                }
-
-                match nums[0] {
-                    1 | 7 => Event::Key(Key::Home),
-                    2 => Event::Key(Key::Insert),
-                    3 => Event::Key(Key::Delete),
-                    4 | 8 => Event::Key(Key::End),
-                    5 => Event::Key(Key::PageUp),
-                    6 => Event::Key(Key::PageDown),
-                    v @ 11...15 => Event::Key(Key::F(v - 10)),
-                    v @ 17...21 => Event::Key(Key::F(v - 11)),
-                    v @ 23...24 => Event::Key(Key::F(v - 12)),
-                    _ => return None,
-                }
-            }
-            _ => return None,
-        }
+        c = iter.next().unwrap().unwrap();
     }
-             _ => return None,
-         })
 
+    match c {
+        // rxvt mouse encoding:
+        // ESC [ Cb ; Cx ; Cy ; M
+        b'M' => {
+            let str_buf = String::from_utf8(buf).unwrap();
+
+            let nums: Vec<u16> = str_buf.split(';').map(|n| n.parse().unwrap()).collect();
+
+            let cb = nums[0];
+            let cx = nums[1];
+            let cy = nums[2];
+
+            let event = match cb {
+                32 => MouseEvent::Press(MouseButton::Left, cx, cy),
+                33 => MouseEvent::Press(MouseButton::Middle, cx, cy),
+                34 => MouseEvent::Press(MouseButton::Right, cx, cy),
+                35 => MouseEvent::Release(cx, cy),
+                64 => MouseEvent::Hold(cx, cy),
+                96 | 97 => MouseEvent::Press(MouseButton::WheelUp, cx, cy),
+                _ => return None,
+            };
+
+            Some(Event::Mouse(event))
+        }
+        // Special key code.
+        b'~' => {
+            let str_buf = String::from_utf8(buf).unwrap();
+
+            // This CSI sequence can be a list of semicolon-separated
+            // numbers.
+            let nums: Vec<u8> = str_buf.split(';').map(|n| n.parse().unwrap()).collect();
+
+            if nums.is_empty() {
+                return None;
+            }
+
+            // TODO: handle multiple values for key modififiers (ex: values
+            // [3, 2] means Shift+Delete)
+            if nums.len() > 1 {
+                return None;
+            }
+
+            match nums[0] {
+                1 | 7 => Some(Event::Key(Key::Home)),
+                2 => Some(Event::Key(Key::Insert)),
+                3 => Some(Event::Key(Key::Delete)),
+                4 | 8 => Some(Event::Key(Key::End)),
+                5 => Some(Event::Key(Key::PageUp)),
+                6 => Some(Event::Key(Key::PageDown)),
+                v @ 11...15 => Some(Event::Key(Key::F(v - 10))),
+                v @ 17...21 => Some(Event::Key(Key::F(v - 11))),
+                v @ 23...24 => Some(Event::Key(Key::F(v - 12))),
+                _ => return None,
+            }
+        }
+        _ => return None,
+    }
+}
+
+fn parse_xterm_mouse<I>(iter: &mut I) -> Option<Event>
+where
+    I: Iterator<Item = Result<u8, Error>>,
+{
+    // xterm mouse encoding:
+    // ESC [ < Cb ; Cx ; Cy (;) (M or m)
+    let mut buf = Vec::new();
+    let mut c = iter.next().unwrap().unwrap();
+    while match c {
+        b'm' | b'M' => false,
+        _ => true,
+    }
+    {
+        buf.push(c);
+        c = iter.next().unwrap().unwrap();
+    }
+    let str_buf = String::from_utf8(buf).unwrap();
+    let nums = &mut str_buf.split(';');
+
+    let cb = nums.next().unwrap().parse::<u16>().unwrap();
+    let cx = nums.next().unwrap().parse::<u16>().unwrap();
+    let cy = nums.next().unwrap().parse::<u16>().unwrap();
+
+    let event = match cb {
+        0...2 | 64...65 => {
+            let button = match cb {
+                0 => MouseButton::Left,
+                1 => MouseButton::Middle,
+                2 => MouseButton::Right,
+                64 => MouseButton::WheelUp,
+                65 => MouseButton::WheelDown,
+                _ => unreachable!(),
+            };
+            match c {
+                b'M' => MouseEvent::Press(button, cx, cy),
+                b'm' => MouseEvent::Release(cx, cy),
+                _ => return None,
+            }
+        }
+        32 => MouseEvent::Hold(cx, cy),
+        3 => MouseEvent::Release(cx, cy),
+        _ => return None,
+    };
+
+    Some(Event::Mouse(event))
+}
+
+fn parse_x10_mouse<I>(iter: &mut I) -> Option<Event>
+where
+    I: Iterator<Item = Result<u8, Error>>,
+{
+    // X10 emulation mouse encoding: ESC [ CB Cx Cy (6 characters only).
+    let mut next = || iter.next().unwrap().unwrap();
+
+    let cb = next() as i8 - 32;
+    // (1, 1) are the coords for upper left.
+    let cx = next().saturating_sub(32) as u16;
+    let cy = next().saturating_sub(32) as u16;
+    Some(Event::Mouse(match cb & 0b11 {
+        0 => {
+            if cb & 0x40 != 0 {
+                MouseEvent::Press(MouseButton::WheelUp, cx, cy)
+            } else {
+                MouseEvent::Press(MouseButton::Left, cx, cy)
+            }
+        }
+        1 => {
+            if cb & 0x40 != 0 {
+                MouseEvent::Press(MouseButton::WheelDown, cx, cy)
+            } else {
+                MouseEvent::Press(MouseButton::Middle, cx, cy)
+            }
+        }
+        2 => MouseEvent::Press(MouseButton::Right, cx, cy),
+        3 => MouseEvent::Release(cx, cy),
+        _ => return None,
+    }))
 }
 
 /// Parse `c` as either a single byte ASCII char or a variable size UTF-8 char.
 fn parse_utf8_char<I>(c: u8, iter: &mut I) -> Result<char, Error>
-    where I: Iterator<Item = Result<u8, Error>>
+where
+    I: Iterator<Item = Result<u8, Error>>,
 {
-    let error = Err(Error::new(ErrorKind::Other, "Input character is not valid UTF-8"));
+    let error = Err(Error::new(
+        ErrorKind::Other,
+        "Input character is not valid UTF-8",
+    ));
     if c.is_ascii() {
         Ok(c as char)
     } else {

--- a/src/event.rs
+++ b/src/event.rs
@@ -3,10 +3,9 @@
 use std::io::{Error, ErrorKind};
 use std::ascii::AsciiExt;
 use std::str;
-use std::cmp::Ordering;
 
 /// An event reported by the terminal.
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(PartialOrd, Ord, Debug, Clone, PartialEq, Eq, Hash)]
 pub enum Event {
     /// A key press.
     Key(Key),
@@ -17,7 +16,7 @@ pub enum Event {
 }
 
 /// A mouse related event.
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[derive(PartialOrd, Ord, Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub enum MouseEvent {
     /// A mouse button was pressed.
     ///
@@ -34,7 +33,7 @@ pub enum MouseEvent {
 }
 
 /// A mouse button.
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[derive(PartialOrd, Ord, Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub enum MouseButton {
     /// The left mouse button.
     Left,
@@ -53,7 +52,7 @@ pub enum MouseButton {
 }
 
 /// A key.
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[derive(PartialOrd, Ord, Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub enum Key {
     /// Backspace.
     Backspace,
@@ -96,64 +95,6 @@ pub enum Key {
 
     #[doc(hidden)]
     __IsNotComplete,
-}
-
-// For reference:
-// http://vimhelp.appspot.com/vim_faq.txt.html#faq-20.5
-// \x00 = ^@
-// \x01 = ^A = <C-A>
-// ...
-// \x09 = ^I = <C-I> = <Tab>
-// ...
-// \x0D = ^M = <C-M> = <C-Enter>
-// ...
-// \x1A = ^Z = <C-Z>
-// \x1B = ^[ = <C-[> = <C-3> = Esc
-// \x1C = ^\ = <C-\> = <C-4>
-// \x1D = ^] = <C-]> = <C-5>
-// \x1E = ^^ = <C-^> = <C-6>
-// \x1F = ^_ = <C-/> = <C-7> = <C-_>
-// \x7F = ^? = <C-?> = <C-8> = <C-Delete> = <C-Bksp>
-fn quantify_key(key: &Key) -> u32 {
-    // http://vimhelp.appspot.com/intro.txt.html#key-codes
-    match *key {
-        Key::Null => 0x00000000u32,
-        Key::Backspace => 0x00000008u32,
-        Key::Esc => 0x0000001Bu32,
-        Key::Delete => 0x0000007Fu32,
-        Key::Insert => 0x40000049u32,
-        Key::Home => 0x4000004Au32,
-        Key::PageUp => 0x4000004Bu32,
-        Key::End => 0x4000004Du32,
-        Key::PageDown => 0x4000004Eu32,
-        Key::Right => 0x4000004Fu32,
-        Key::Left => 0x40000050u32,
-        Key::Down => 0x40000051u32,
-        Key::Up => 0x40000052u32,
-        Key::F(b) => {
-            match b {
-                1...12 => (b as u32) + 0x40000039u32,
-                13...24 => (b as u32) + 0x4000005Au32,
-                _ => 0x00,
-            }
-        }
-        Key::Char(c) => c as u32,
-        Key::Alt(c) => (c as u32) | 0x10,
-        Key::Ctrl(c) => ((c as u32) - ('A' as u32) + 1),
-        Key::__IsNotComplete => 0x00,
-    }
-}
-
-impl PartialOrd for Key {
-    fn partial_cmp(&self, other: &Key) -> Option<Ordering> {
-        Some(self.cmp(other))
-    }
-}
-
-impl Ord for Key {
-    fn cmp(&self, other: &Key) -> Ordering {
-        quantify_key(self).cmp(&quantify_key(other))
-    }
 }
 
 /// Parse an Event from `item` and possibly subsequent bytes through `iter`.

--- a/src/input.rs
+++ b/src/input.rs
@@ -27,15 +27,17 @@ impl<R: Read> Iterator for Keys<R> {
 }
 
 /// An iterator over input events.
-pub struct Events<R>  {
-    inner: EventsAndRaw<R>
+pub struct Events<R> {
+    inner: EventsAndRaw<R>,
 }
 
 impl<R: Read> Iterator for Events<R> {
     type Item = Result<Event, io::Error>;
 
     fn next(&mut self) -> Option<Result<Event, io::Error>> {
-        self.inner.next().map(|tuple| tuple.map(|(event, _raw)| event))
+        self.inner.next().map(
+            |tuple| tuple.map(|(event, _raw)| event),
+        )
     }
 }
 
@@ -73,7 +75,8 @@ impl<R: Read> Iterator for EventsAndRaw<R> {
             Ok(2) => {
                 let option_iter = &mut Some(buf[1]).into_iter();
                 let result = {
-                    let mut iter = option_iter.map(|c| Ok(c)).chain(source.bytes());
+                    let mut iter =
+                        option_iter.map(|c| Ok(c)).chain(source.bytes());
                     parse_event(buf[0], &mut iter)
                 };
                 // If the option_iter wasn't consumed, keep the byte for later.
@@ -89,26 +92,33 @@ impl<R: Read> Iterator for EventsAndRaw<R> {
 }
 
 fn parse_event<I>(item: u8, iter: &mut I) -> Result<(Event, Vec<u8>), io::Error>
-    where I: Iterator<Item = Result<u8, io::Error>>
+where
+    I: Iterator<Item = Result<u8, io::Error>>,
 {
     let mut buf = vec![item];
     let result = {
         let mut iter = iter.inspect(|byte| if let &Ok(byte) = byte {
-                                        buf.push(byte);
-                                    });
+            buf.push(byte);
+        });
         event::parse_event(item, &mut iter)
     };
-    result.or(Ok(Event::Unsupported(buf.clone()))).map(|e| (e, buf))
+    result.or(Ok(Event::Unsupported(buf.clone()))).map(
+        |e| (e, buf),
+    )
 }
 
 
 /// Extension to `Read` trait.
 pub trait TermRead {
     /// An iterator over input events.
-    fn events(self) -> Events<Self> where Self: Sized;
+    fn events(self) -> Events<Self>
+    where
+        Self: Sized;
 
     /// An iterator over key inputs.
-    fn keys(self) -> Keys<Self> where Self: Sized;
+    fn keys(self) -> Keys<Self>
+    where
+        Self: Sized;
 
     /// Read a line.
     ///
@@ -120,7 +130,10 @@ pub trait TermRead {
     ///
     /// EOT and ETX will abort the prompt, returning `None`. Newline or carriage return will
     /// complete the input.
-    fn read_passwd<W: Write>(&mut self, writer: &mut W) -> io::Result<Option<String>> {
+    fn read_passwd<W: Write>(
+        &mut self,
+        writer: &mut W,
+    ) -> io::Result<Option<String>> {
         let _raw = try!(writer.into_raw_mode());
         self.read_line()
     }
@@ -129,9 +142,7 @@ pub trait TermRead {
 
 impl<R: Read + TermReadEventsAndRaw> TermRead for R {
     fn events(self) -> Events<Self> {
-        Events {
-            inner: self.events_and_raw()
-        }
+        Events { inner: self.events_and_raw() }
     }
     fn keys(self) -> Keys<Self> {
         Keys { iter: self.events() }
@@ -152,8 +163,9 @@ impl<R: Read + TermReadEventsAndRaw> TermRead for R {
             }
         }
 
-        let string = try!(String::from_utf8(buf)
-            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e)));
+        let string = try!(String::from_utf8(buf).map_err(|e| {
+            io::Error::new(io::ErrorKind::InvalidData, e)
+        }));
         Ok(Some(string))
     }
 }
@@ -161,7 +173,9 @@ impl<R: Read + TermReadEventsAndRaw> TermRead for R {
 /// Extension to `TermRead` trait. A separate trait in order to maintain backwards compatibility.
 pub trait TermReadEventsAndRaw {
     /// An iterator over input events and the bytes that define them.
-    fn events_and_raw(self) -> EventsAndRaw<Self> where Self: Sized;
+    fn events_and_raw(self) -> EventsAndRaw<Self>
+    where
+        Self: Sized;
 }
 
 impl<R: Read> TermReadEventsAndRaw for R {
@@ -174,10 +188,12 @@ impl<R: Read> TermReadEventsAndRaw for R {
 }
 
 /// A sequence of escape codes to enable terminal mouse support.
-const ENTER_MOUSE_SEQUENCE: &'static str = csi!("?1000h\x1b[?1002h\x1b[?1015h\x1b[?1006h");
+const ENTER_MOUSE_SEQUENCE: &'static str =
+    csi!("?1000h\x1b[?1002h\x1b[?1015h\x1b[?1006h");
 
 /// A sequence of escape codes to disable terminal mouse support.
-const EXIT_MOUSE_SEQUENCE: &'static str = csi!("?1006l\x1b[?1015l\x1b[?1002l\x1b[?1000l");
+const EXIT_MOUSE_SEQUENCE: &'static str =
+    csi!("?1006l\x1b[?1015l\x1b[?1002l\x1b[?1000l");
 
 /// A terminal with added mouse support.
 ///
@@ -249,22 +265,34 @@ mod test {
                     \x1B[M\x00\x22\x24\x1B[<0;2;4;M\x1B[32;2;4M\x1B[<0;2;4;m\x1B[35;2;4Mb"
                     .events();
 
-        assert_eq!(i.next().unwrap().unwrap(),
-                   Event::Unsupported(vec![0x1B, b'[', 0x00]));
+        assert_eq!(
+            i.next().unwrap().unwrap(),
+            Event::Unsupported(vec![0x1B, b'[', 0x00])
+        );
         assert_eq!(i.next().unwrap().unwrap(), Event::Key(Key::Char('b')));
         assert_eq!(i.next().unwrap().unwrap(), Event::Key(Key::Char('c')));
         assert_eq!(i.next().unwrap().unwrap(), Event::Key(Key::Backspace));
         assert_eq!(i.next().unwrap().unwrap(), Event::Key(Key::Left));
-        assert_eq!(i.next().unwrap().unwrap(),
-                   Event::Mouse(MouseEvent::Press(MouseButton::WheelUp, 2, 4)));
-        assert_eq!(i.next().unwrap().unwrap(),
-                   Event::Mouse(MouseEvent::Press(MouseButton::Left, 2, 4)));
-        assert_eq!(i.next().unwrap().unwrap(),
-                   Event::Mouse(MouseEvent::Press(MouseButton::Left, 2, 4)));
-        assert_eq!(i.next().unwrap().unwrap(),
-                   Event::Mouse(MouseEvent::Release(2, 4)));
-        assert_eq!(i.next().unwrap().unwrap(),
-                   Event::Mouse(MouseEvent::Release(2, 4)));
+        assert_eq!(
+            i.next().unwrap().unwrap(),
+            Event::Mouse(MouseEvent::Press(MouseButton::WheelUp, 2, 4))
+        );
+        assert_eq!(
+            i.next().unwrap().unwrap(),
+            Event::Mouse(MouseEvent::Press(MouseButton::Left, 2, 4))
+        );
+        assert_eq!(
+            i.next().unwrap().unwrap(),
+            Event::Mouse(MouseEvent::Press(MouseButton::Left, 2, 4))
+        );
+        assert_eq!(
+            i.next().unwrap().unwrap(),
+            Event::Mouse(MouseEvent::Release(2, 4))
+        );
+        assert_eq!(
+            i.next().unwrap().unwrap(),
+            Event::Mouse(MouseEvent::Release(2, 4))
+        );
         assert_eq!(i.next().unwrap().unwrap(), Event::Key(Key::Char('b')));
         assert!(i.next().is_none());
     }
@@ -275,25 +303,40 @@ mod test {
                     \x1B[M\x00\x22\x24\x1B[<0;2;4;M\x1B[32;2;4M\x1B[<0;2;4;m\x1B[35;2;4Mb";
         let mut output = Vec::<u8>::new();
         {
-            let mut i = input.events_and_raw().map(|res| res.unwrap())
-                .inspect(|&(_, ref raw)| { output.extend(raw); }).map(|(event, _)| event);
+            let mut i = input
+                .events_and_raw()
+                .map(|res| res.unwrap())
+                .inspect(|&(_, ref raw)| { output.extend(raw); })
+                .map(|(event, _)| event);
 
-            assert_eq!(i.next().unwrap(),
-            Event::Unsupported(vec![0x1B, b'[', 0x00]));
+            assert_eq!(
+                i.next().unwrap(),
+                Event::Unsupported(vec![0x1B, b'[', 0x00])
+            );
             assert_eq!(i.next().unwrap(), Event::Key(Key::Char('b')));
             assert_eq!(i.next().unwrap(), Event::Key(Key::Char('c')));
             assert_eq!(i.next().unwrap(), Event::Key(Key::Backspace));
             assert_eq!(i.next().unwrap(), Event::Key(Key::Left));
-            assert_eq!(i.next().unwrap(),
-            Event::Mouse(MouseEvent::Press(MouseButton::WheelUp, 2, 4)));
-            assert_eq!(i.next().unwrap(),
-            Event::Mouse(MouseEvent::Press(MouseButton::Left, 2, 4)));
-            assert_eq!(i.next().unwrap(),
-            Event::Mouse(MouseEvent::Press(MouseButton::Left, 2, 4)));
-            assert_eq!(i.next().unwrap(),
-            Event::Mouse(MouseEvent::Release(2, 4)));
-            assert_eq!(i.next().unwrap(),
-            Event::Mouse(MouseEvent::Release(2, 4)));
+            assert_eq!(
+                i.next().unwrap(),
+                Event::Mouse(MouseEvent::Press(MouseButton::WheelUp, 2, 4))
+            );
+            assert_eq!(
+                i.next().unwrap(),
+                Event::Mouse(MouseEvent::Press(MouseButton::Left, 2, 4))
+            );
+            assert_eq!(
+                i.next().unwrap(),
+                Event::Mouse(MouseEvent::Press(MouseButton::Left, 2, 4))
+            );
+            assert_eq!(
+                i.next().unwrap(),
+                Event::Mouse(MouseEvent::Release(2, 4))
+            );
+            assert_eq!(
+                i.next().unwrap(),
+                Event::Mouse(MouseEvent::Release(2, 4))
+            );
             assert_eq!(i.next().unwrap(), Event::Key(Key::Char('b')));
             assert!(i.next().is_none());
         }
@@ -310,7 +353,7 @@ mod test {
 
         let mut st = b"\x1B[11~\x1B[12~\x1B[13~\x1B[14~\x1B[15~\
         \x1B[17~\x1B[18~\x1B[19~\x1B[20~\x1B[21~\x1B[23~\x1B[24~"
-                .keys();
+            .keys();
         for i in 1..13 {
             assert_eq!(st.next().unwrap().unwrap(), Key::F(i));
         }
@@ -318,7 +361,8 @@ mod test {
 
     #[test]
     fn test_special_keys() {
-        let mut st = b"\x1B[2~\x1B[H\x1B[7~\x1B[5~\x1B[3~\x1B[F\x1B[8~\x1B[6~".keys();
+        let mut st = b"\x1B[2~\x1B[H\x1B[7~\x1B[5~\x1B[3~\x1B[F\x1B[8~\x1B[6~"
+            .keys();
         assert_eq!(st.next().unwrap().unwrap(), Key::Insert);
         assert_eq!(st.next().unwrap().unwrap(), Key::Home);
         assert_eq!(st.next().unwrap().unwrap(), Key::Home);
@@ -365,24 +409,35 @@ mod test {
 
     #[test]
     fn test_backspace() {
-        line_match("this is the\x7f first\x7f\x7f test",
-                   Some("this is th fir test"));
-        line_match("this is the seco\x7fnd test\x7f",
-                   Some("this is the secnd tes"));
+        line_match(
+            "this is the\x7f first\x7f\x7f test",
+            Some("this is th fir test"),
+        );
+        line_match(
+            "this is the seco\x7fnd test\x7f",
+            Some("this is the secnd tes"),
+        );
     }
 
     #[test]
     fn test_end() {
-        line_match("abc\nhttps://www.youtube.com/watch?v=dQw4w9WgXcQ",
-                   Some("abc"));
-        line_match("hello\rhttps://www.youtube.com/watch?v=yPYZpwSpKmA",
-                   Some("hello"));
+        line_match(
+            "abc\nhttps://www.youtube.com/watch?v=dQw4w9WgXcQ",
+            Some("abc"),
+        );
+        line_match(
+            "hello\rhttps://www.youtube.com/watch?v=yPYZpwSpKmA",
+            Some("hello"),
+        );
     }
 
     #[test]
     fn test_abort() {
         line_match("abc\x03https://www.youtube.com/watch?v=dQw4w9WgXcQ", None);
-        line_match("hello\x04https://www.youtube.com/watch?v=yPYZpwSpKmA", None);
+        line_match(
+            "hello\x04https://www.youtube.com/watch?v=yPYZpwSpKmA",
+            None,
+        );
     }
 
 }

--- a/src/input.rs
+++ b/src/input.rs
@@ -49,7 +49,7 @@ impl<R: Read> Iterator for EventsAndRaw<R> {
     type Item = Result<(Event, Vec<u8>), io::Error>;
 
     fn next(&mut self) -> Option<Result<(Event, Vec<u8>), io::Error>> {
-        let mut source = &mut self.source;
+        let source = &mut self.source;
 
         if let Some(c) = self.leftover {
             // we have a leftover byte, use it
@@ -71,7 +71,7 @@ impl<R: Read> Iterator for EventsAndRaw<R> {
                 }
             }
             Ok(2) => {
-                let mut option_iter = &mut Some(buf[1]).into_iter();
+                let option_iter = &mut Some(buf[1]).into_iter();
                 let result = {
                     let mut iter = option_iter.map(|c| Ok(c)).chain(source.bytes());
                     parse_event(buf[0], &mut iter)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,12 +11,18 @@
 //! For more information refer to the [README](https://github.com/ticki/termion).
 #![warn(missing_docs)]
 
+extern crate serde;
+extern crate serde_json;
+
+#[macro_use]
+extern crate serde_derive;
+
 #[cfg(target_os = "redox")]
-#[path="sys/redox/mod.rs"]
+#[path = "sys/redox/mod.rs"]
 mod sys;
 
 #[cfg(unix)]
-#[path="sys/unix/mod.rs"]
+#[path = "sys/unix/mod.rs"]
 mod sys;
 
 pub use sys::size::terminal_size;

--- a/src/screen.rs
+++ b/src/screen.rs
@@ -55,7 +55,9 @@ impl<W: Write> AlternateScreen<W> {
     /// Create an alternate screen wrapper struct for the provided output and switch the terminal
     /// to the alternate screen.
     pub fn from(mut output: W) -> Self {
-        write!(output, "{}", ToAlternateScreen).expect("switch to alternate screen");
+        write!(output, "{}", ToAlternateScreen).expect(
+            "switch to alternate screen",
+        );
         AlternateScreen { output: output }
     }
 }

--- a/src/style.rs
+++ b/src/style.rs
@@ -9,14 +9,28 @@ derive_csi_sequence!("Italic text.", Italic, "3m");
 derive_csi_sequence!("Underlined text.", Underline, "4m");
 derive_csi_sequence!("Blinking text (not widely supported).", Blink, "5m");
 derive_csi_sequence!("Inverted colors (negative mode).", Invert, "7m");
-derive_csi_sequence!("Crossed out text (not widely supported).", CrossedOut, "9m");
+derive_csi_sequence!(
+    "Crossed out text (not widely supported).",
+    CrossedOut,
+    "9m"
+);
 derive_csi_sequence!("Undo bold text.", NoBold, "21m");
-derive_csi_sequence!("Undo fainted text (not widely supported).", NoFaint, "22m");
+derive_csi_sequence!(
+    "Undo fainted text (not widely supported).",
+    NoFaint,
+    "22m"
+);
 derive_csi_sequence!("Undo italic text.", NoItalic, "23m");
 derive_csi_sequence!("Undo underlined text.", NoUnderline, "24m");
-derive_csi_sequence!("Undo blinking text (not widely supported).", NoBlink, "25m");
+derive_csi_sequence!(
+    "Undo blinking text (not widely supported).",
+    NoBlink,
+    "25m"
+);
 derive_csi_sequence!("Undo inverted colors (negative mode).", NoInvert, "27m");
-derive_csi_sequence!("Undo crossed out text (not widely supported).",
-                     NoCrossedOut,
-                     "29m");
+derive_csi_sequence!(
+    "Undo crossed out text (not widely supported).",
+    NoCrossedOut,
+    "29m"
+);
 derive_csi_sequence!("Framed text (not widely supported).", Framed, "51m");

--- a/src/sys/redox/attr.rs
+++ b/src/sys/redox/attr.rs
@@ -12,7 +12,10 @@ pub fn get_terminal_attr() -> io::Result<Termios> {
     if res? == termios.len() {
         Ok(termios)
     } else {
-        Err(io::Error::new(io::ErrorKind::Other, "Unable to get the terminal attributes."))
+        Err(io::Error::new(
+            io::ErrorKind::Other,
+            "Unable to get the terminal attributes.",
+        ))
     }
 }
 
@@ -24,7 +27,10 @@ pub fn set_terminal_attr(termios: &Termios) -> io::Result<()> {
     if res? == termios.len() {
         Ok(())
     } else {
-        Err(io::Error::new(io::ErrorKind::Other, "Unable to set the terminal attributes."))
+        Err(io::Error::new(
+            io::ErrorKind::Other,
+            "Unable to set the terminal attributes.",
+        ))
     }
 }
 

--- a/src/sys/redox/size.rs
+++ b/src/sys/redox/size.rs
@@ -13,6 +13,9 @@ pub fn terminal_size() -> io::Result<(u16, u16)> {
     if res? == winsize.len() {
         Ok((winsize.ws_col, winsize.ws_row))
     } else {
-        Err(io::Error::new(io::ErrorKind::Other, "Unable to get the terminal size."))
+        Err(io::Error::new(
+            io::ErrorKind::Other,
+            "Unable to get the terminal size.",
+        ))
     }
 }

--- a/src/sys/redox/tty.rs
+++ b/src/sys/redox/tty.rs
@@ -17,6 +17,8 @@ pub fn is_tty<T: AsRawFd>(stream: &T) -> bool {
 ///
 /// This allows for getting stdio representing _only_ the TTY, and not other streams.
 pub fn get_tty() -> io::Result<fs::File> {
-    let tty = try!(env::var("TTY").map_err(|x| io::Error::new(io::ErrorKind::NotFound, x)));
+    let tty = try!(env::var("TTY").map_err(|x| {
+        io::Error::new(io::ErrorKind::NotFound, x)
+    }));
     fs::OpenOptions::new().read(true).write(true).open(tty)
 }

--- a/src/sys/unix/attr.rs
+++ b/src/sys/unix/attr.rs
@@ -16,7 +16,11 @@ pub fn get_terminal_attr() -> io::Result<Termios> {
 
 pub fn set_terminal_attr(termios: &Termios) -> io::Result<()> {
     extern "C" {
-        pub fn tcsetattr(fd: c_int, opt: c_int, termptr: *const Termios) -> c_int;
+        pub fn tcsetattr(
+            fd: c_int,
+            opt: c_int,
+            termptr: *const Termios,
+        ) -> c_int;
     }
     cvt(unsafe { tcsetattr(0, 0, termios) }).and(Ok(()))
 }

--- a/src/sys/unix/tty.rs
+++ b/src/sys/unix/tty.rs
@@ -13,5 +13,7 @@ pub fn is_tty<T: AsRawFd>(stream: &T) -> bool {
 ///
 /// This allows for getting stdio representing _only_ the TTY, and not other streams.
 pub fn get_tty() -> io::Result<fs::File> {
-    fs::OpenOptions::new().read(true).write(true).open("/dev/tty")
+    fs::OpenOptions::new().read(true).write(true).open(
+        "/dev/tty",
+    )
 }


### PR DESCRIPTION
This changeset adds an explicit detection and parsing of `Key::Esc`. A minor refactor was done in order to determine how best to achieve the parse. Finally, `rustfmt` was applied using default config.