### PR TITLE
Implemented color for Box<Color> so color can be passed around

### DIFF
--- a/src/color.rs
+++ b/src/color.rs
@@ -27,6 +27,17 @@ pub trait Color {
     fn write_bg(&self, f: &mut fmt::Formatter) -> fmt::Result;
 }
 
+/// Color implementation for boxed version of color
+impl<'a> Color for Box<Color + 'a> {
+    fn write_fg(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        self.deref().write_fg(f)
+    }
+
+    fn write_bg(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        self.deref().write_bg(f)
+    }
+}
+
 macro_rules! derive_color {
     ($doc:expr, $name:ident, $value:expr) => {
         #[doc = $doc]

--- a/src/color.rs
+++ b/src/color.rs
@@ -18,6 +18,7 @@ use std::io::{self, Write, Read};
 use std::time::{SystemTime, Duration};
 use async::async_stdin;
 use std::env;
+use std::ops::Deref;
 
 /// A terminal color.
 pub trait Color {


### PR DESCRIPTION
Implemented color for Box<Color> so color can be passed around and doesnt cause problems with sized not being implemented (see issue 123).