### PR TITLE
Adds 1ms timeout to async read

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 target
 Cargo.lock
+*.swp

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ exclude = ["target", "CHANGELOG.md", "image.png", "Cargo.lock"]
 
 [dependencies]
 numtoa = { version = "0.1.0", features = ["std"]}
+crossbeam-channel = "0.2"
 
 [target.'cfg(not(target_os = "redox"))'.dependencies]
 libc = "0.2.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "termion"
-version = "1.5.1"
+version = "1.5.2"
 authors = ["ticki <Ticki@users.noreply.github.com>", "gycos <alexandre.bury@gmail.com>", "IGI-111 <igi-111@protonmail.com>"]
 description = "A bindless library for manipulating terminals."
 repository = "https://gitlab.redox-os.org/redox-os/termion"

--- a/examples/async.rs
+++ b/examples/async.rs
@@ -17,22 +17,28 @@ fn main() {
            termion::cursor::Goto(1, 1))
             .unwrap();
 
-    loop {
+    let mut buf = String::new();
+    'a: loop {
         write!(stdout, "{}", termion::clear::CurrentLine).unwrap();
 
-        let b = stdin.next();
-        write!(stdout, "\r{:?}    <- This demonstrates the async read input char. Between each update a 100 ms. is waited, simply to demonstrate the async fashion. \n\r", b).unwrap();
-        if let Some(Ok(b'q')) = b {
-            break;
-        }
+        write!(stdout, "\r{}    <- This demonstrates the async read input char. \
+               Between each update a 100 ms. is waited, simply to demonstrate the async fashion. \n\r", buf).unwrap();
+
+        while let Some(next) = stdin.next() { match next {
+            Ok(b'q') => break 'a,
+
+            Ok(c) => buf.push(c as char),
+
+            Err(e) => panic!("error: {:?}", e),
+        }}
 
         stdout.flush().unwrap();
 
-        thread::sleep(Duration::from_millis(50));
-        stdout.write_all(b"# ").unwrap();
-        stdout.flush().unwrap();
-        thread::sleep(Duration::from_millis(50));
-        stdout.write_all(b"\r #").unwrap();
+        //thread::sleep(Duration::from_millis(200));
+        //stdout.write_all(b"# ").unwrap();
+        //stdout.flush().unwrap();
+        thread::sleep(Duration::from_millis(100));
+        //stdout.write_all(b"\r #").unwrap();
         write!(stdout, "{}", termion::cursor::Goto(1, 1)).unwrap();
         stdout.flush().unwrap();
     }

--- a/examples/color.rs
+++ b/examples/color.rs
@@ -1,10 +1,15 @@
 extern crate termion;
 
-use termion::{color, style};
+use termion::{color::{self, Fg}, style};
 
 fn main() {
     println!("{}Red", color::Fg(color::Red));
     println!("{}Blue", color::Fg(color::Blue));
     println!("{}Blue'n'Bold{}", style::Bold, style::Reset);
     println!("{}Just plain italic{}", style::Italic, style::Reset);
+
+    println!("{}", style::Reset);
+
+    println!("{}Yellow{}", color::Fg(color::Yellow), Fg(color::Reset));
+    println!("{}LightYellow{}", color::Fg(color::LightYellow), Fg(color::Reset));
 }

--- a/src/async.rs
+++ b/src/async.rs
@@ -1,25 +1,32 @@
 use std::io::{self, Read};
-use std::sync::mpsc;
+//use std::sync::mpsc;
 use std::thread;
 use std::time::Duration;
+use crossbeam_channel::{self as channel, bounded, Receiver};
 
 use sys::tty::get_tty;
+
+const QUEUE_SIZE: usize = 32;
+const TIMEOUT: Duration = Duration::from_millis(1);
 
 /// Construct an asynchronous handle to the TTY standard input, with a delimiter byte.
 ///
 /// This has the same advantages as async_stdin(), but also allows specifying a delimiter byte. The
 /// reader will stop reading after consuming the delimiter byte.
 pub fn async_stdin_until(delimiter: u8) -> AsyncReader {
-    let (send, recv) = mpsc::channel();
+    //let (send, recv) = mpsc::channel();
+    let (send, recv) = bounded(QUEUE_SIZE);
 
     thread::spawn(move || for i in get_tty().unwrap().bytes() {
 
         match i {
             Ok(byte) => {
                 let end_of_stream = &byte == &delimiter;
-                let send_error = send.send(Ok(byte)).is_err();
+                if end_of_stream { return }
+                send.send(Ok(byte));
 
-                if end_of_stream || send_error { return; }
+                //let send_error = send.send(Ok(byte)).is_err();
+                //if end_of_stream || send_error { return; }
             },
             Err(_) => { return; }
         }
@@ -39,13 +46,18 @@ pub fn async_stdin_until(delimiter: u8) -> AsyncReader {
 /// output from another process, it won't be reflected in the stream returned by this function, as
 /// this represents the TTY device, and not the piped standard input.
 pub fn async_stdin() -> AsyncReader {
-    let (send, recv) = mpsc::channel();
+    //let (send, recv) = mpsc::channel();
+    let (send, recv) = bounded(QUEUE_SIZE);
 
-    thread::spawn(move || for i in get_tty().unwrap().bytes() {
-                      if send.send(i).is_err() {
-                          return;
-                      }
-                  });
+    thread::spawn(move || {
+        for i in get_tty().unwrap().bytes() {
+            send.send(i);
+        }
+    });
+                      // if send.send(i).is_err() {
+                      //     return;
+                      // }
+                  //});
 
     AsyncReader { recv: recv }
 }
@@ -56,7 +68,8 @@ pub fn async_stdin() -> AsyncReader {
 /// the buffer will only be partially updated based on how much the internal buffer holds.
 pub struct AsyncReader {
     /// The underlying mpsc receiver.
-    recv: mpsc::Receiver<io::Result<u8>>,
+    //recv: mpsc::Receiver<io::Result<u8>>,
+    recv: Receiver<io::Result<u8>>,
 }
 
 // FIXME: Allow constructing an async reader from an arbitrary stream.
@@ -64,9 +77,7 @@ pub struct AsyncReader {
 impl Read for AsyncReader {
     /// Read from the byte stream.
     ///
-    /// This will never block, but try to drain the event queue until empty. If the total number of
-    /// bytes written is lower than the buffer's length, the event queue is empty or that the event
-    /// stream halted.
+    /// This may block a short duration (see `TIMEOUT`).
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         let mut total = 0;
 
@@ -75,13 +86,21 @@ impl Read for AsyncReader {
                 break;
             }
 
-            match self.recv.recv_timeout(Duration::from_millis(1)) {
-                Ok(Ok(b)) => {
-                    buf[total] = b;
-                    total += 1;
+            select! {
+                recv(self.recv, msg) => {
+                    match msg {
+                        Some(Ok(b)) => {
+                            buf[total] = b;
+                            total += 1;
+                        }
+
+                        Some(Err(e)) => return Err(e),
+
+                        None => break,
+                    }
                 }
-                Ok(Err(e)) => return Err(e),
-                Err(_) => break,
+
+                recv(channel::after(TIMEOUT)) => break,
             }
         }
 

--- a/src/async.rs
+++ b/src/async.rs
@@ -1,6 +1,7 @@
 use std::io::{self, Read};
 use std::sync::mpsc;
 use std::thread;
+use std::time::Duration;
 
 use sys::tty::get_tty;
 
@@ -51,7 +52,7 @@ impl Read for AsyncReader {
                 break;
             }
 
-            match self.recv.try_recv() {
+            match self.recv.recv_timeout(Duration::from_millis(1)) {
                 Ok(Ok(b)) => {
                     buf[total] = b;
                     total += 1;

--- a/src/async.rs
+++ b/src/async.rs
@@ -6,7 +6,7 @@ use crossbeam_channel::{self as channel, bounded, Receiver};
 
 use sys::tty::get_tty;
 
-const QUEUE_SIZE: usize = 32;
+const QUEUE_SIZE: usize = 128;
 const TIMEOUT: Duration = Duration::from_millis(1);
 
 /// Construct an asynchronous handle to the TTY standard input, with a delimiter byte.

--- a/src/event.rs
+++ b/src/event.rs
@@ -1,6 +1,7 @@
 //! Mouse and key events.
 
 use std::io::{Error, ErrorKind};
+#[allow(unused_imports)]
 use std::ascii::AsciiExt;
 use std::str;
 

--- a/src/event.rs
+++ b/src/event.rs
@@ -1,8 +1,6 @@
 //! Mouse and key events.
 
 use std::io::{Error, ErrorKind};
-#[allow(unused_imports)]
-use std::ascii::AsciiExt;
 use std::str;
 
 /// An event reported by the terminal.

--- a/src/event.rs
+++ b/src/event.rs
@@ -2,7 +2,6 @@
 
 use std::io::{Error, ErrorKind};
 #[allow(unused_imports)]
-use std::ascii::AsciiExt;
 use std::str;
 
 /// An event reported by the terminal.

--- a/src/input.rs
+++ b/src/input.rs
@@ -49,7 +49,7 @@ impl<R: Read> Iterator for EventsAndRaw<R> {
     type Item = Result<(Event, Vec<u8>), io::Error>;
 
     fn next(&mut self) -> Option<Result<(Event, Vec<u8>), io::Error>> {
-        let mut source = &mut self.source;
+        let source = &mut self.source;
 
         if let Some(c) = self.leftover {
             // we have a leftover byte, use it

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,8 @@
 #![warn(missing_docs)]
 
 extern crate numtoa;
+#[macro_use]
+extern crate crossbeam_channel;
 
 #[cfg(target_os = "redox")]
 #[path="sys/redox/mod.rs"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,6 @@
 //! Supports Redox, Mac OS X, and Linux (or, in general, ANSI terminals).
 //!
 //! For more information refer to the [README](https://github.com/redox-os/termion).
-#![warn(missing_docs)]
 
 extern crate numtoa;
 #[macro_use]


### PR DESCRIPTION
This seems to solve a problem of corrupted `Key` parsing from consecutive left arrow presses. Not sure what the ramifications of this change are though, as I didn't spend too much time delving into the codebase.

I also didn't spend any time tuning the `Duration` to see what the minimum working size was. 