### PR TITLE
remove unused import and unused mut

### DIFF
--- a/src/event.rs
+++ b/src/event.rs
@@ -1,7 +1,6 @@
 //! Mouse and key events.
 
 use std::io::{Error, ErrorKind};
-use std::ascii::AsciiExt;
 use std::str;
 
 /// An event reported by the terminal.

--- a/src/input.rs
+++ b/src/input.rs
@@ -49,7 +49,7 @@ impl<R: Read> Iterator for EventsAndRaw<R> {
     type Item = Result<(Event, Vec<u8>), io::Error>;
 
     fn next(&mut self) -> Option<Result<(Event, Vec<u8>), io::Error>> {
-        let mut source = &mut self.source;
+        let source = &mut self.source;
 
         if let Some(c) = self.leftover {
             // we have a leftover byte, use it


### PR DESCRIPTION
Remove unused import and unnecessary `mut`. It shouldn't have any undesired side effects.

cc @ticki 