### PR TITLE
Reset style in color example before exit

### DIFF
--- a/examples/color.rs
+++ b/examples/color.rs
@@ -6,5 +6,5 @@ fn main() {
     println!("{}Red", color::Fg(color::Red));
     println!("{}Blue", color::Fg(color::Blue));
     println!("{}Blue'n'Bold{}", style::Bold, style::Reset);
-    println!("{}Just plain italic", style::Italic);
+    println!("{}Just plain italic{}", style::Italic, style::Reset);
 }


### PR DESCRIPTION
The color example leaves the terminal a little italic after exiting without the style reset.