### PR TITLE
Remove unused import of std::ascii::AsciiExt

### DIFF
--- a/src/event.rs
+++ b/src/event.rs
@@ -1,7 +1,6 @@
 //! Mouse and key events.
 
 use std::io::{Error, ErrorKind};
-use std::ascii::AsciiExt;
 use std::str;
 
 /// An event reported by the terminal.


### PR DESCRIPTION
The import of std::ascii::AsciiExt in src/event.rs is unused. Remove it.

> warning: unused import: `std::ascii::AsciiExt`
>  --> src/event.rs:4:5
>   |
> 4 | use std::ascii::AsciiExt;
>   |     ^^^^^^^^^^^^^^^^^^^^
>   |
>   = note: #[warn(unused_imports)] on by default