### PR TITLE
Remove unused 'mut' qualifier in src/input.rs

### DIFF
--- a/src/input.rs
+++ b/src/input.rs
@@ -49,7 +49,7 @@ impl<R: Read> Iterator for EventsAndRaw<R> {
     type Item = Result<(Event, Vec<u8>), io::Error>;
 
     fn next(&mut self) -> Option<Result<(Event, Vec<u8>), io::Error>> {
-        let mut source = &mut self.source;
+        let source = &mut self.source;
 
         if let Some(c) = self.leftover {
             // we have a leftover byte, use it


### PR DESCRIPTION
This change removes an unused 'mut' qualifier of the 'source' variable
in src/input.rs.

> warning: variable does not need to be mutable
>   --> src/input.rs:52:13
>    |
> 52 |         let mut source = &mut self.source;
>    |             ----^^^^^^
>    |             |
>    |             help: remove this `mut`
>    |
>    = note: #[warn(unused_mut)] on by default