### PR TITLE
Add ability to suspend/activate raw mode on RawTerminal

### DIFF
--- a/src/raw.rs
+++ b/src/raw.rs
@@ -101,6 +101,20 @@ impl<W: Write> IntoRawMode for W {
     }
 }
 
+impl<W: Write> RawTerminal<W> {
+    pub fn suspend_raw_mode(&self) -> io::Result<()> {
+        set_terminal_attr(&self.prev_ios)?;
+        Ok(())
+    }
+
+    pub fn activate_raw_mode(&self) -> io::Result<()> {
+        let mut ios = get_terminal_attr()?;
+        raw_terminal_attr(&mut ios);
+        set_terminal_attr(&ios)?;
+        Ok(())
+    }
+}
+
 #[cfg(test)]
 mod test {
     use super::*;


### PR DESCRIPTION
I'm by no means proposing this as the correct code solution, it is however allowing me to use the `raw` module for the purposes of my shell. If there is a better way to already do this please feel free to close, otherwise I'm open to better solutions.