### PR TITLE
Eliminated unwraps to avoid panics

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ exclude = ["target", "CHANGELOG.md", "image.png", "Cargo.lock"]
 
 [dependencies]
 numtoa = { version = "0.1.0", features = ["std"]}
+log = "0.4"
 
 [target.'cfg(not(target_os = "redox"))'.dependencies]
 libc = "0.2.8"

--- a/src/async.rs
+++ b/src/async.rs
@@ -89,9 +89,10 @@ impl Read for AsyncReader {
                     total += 1;
                 }
                 Ok(Err(e)) => return Err(e),
-                Err(e) => {
-                    warn!("Receive error {}", e);
-                    break;
+                Err(mpsc::TryRecvError::Empty) => break,
+                Err(mpsc::TryRecvError::Disconnected) => {
+                    warn!("Receiver disconnected");
+                    return Err(io::Error::from(io::ErrorKind::BrokenPipe));
                 }
             }
         }

--- a/src/async.rs
+++ b/src/async.rs
@@ -11,16 +11,23 @@ use sys::tty::get_tty;
 pub fn async_stdin_until(delimiter: u8) -> AsyncReader {
     let (send, recv) = mpsc::channel();
 
-    thread::spawn(move || for i in get_tty().unwrap().bytes() {
+    thread::spawn(move || {
+        for i in get_tty().unwrap().bytes() {
+            match i {
+                Ok(byte) => {
+                    let end_of_stream = &byte == &delimiter;
+                    let send_error = send.send(Ok(byte)).is_err();
 
-        match i {
-            Ok(byte) => {
-                let end_of_stream = &byte == &delimiter;
-                let send_error = send.send(Ok(byte)).is_err();
-
-                if end_of_stream || send_error { return; }
-            },
-            Err(_) => { return; }
+                    if end_of_stream || send_error {
+                        warn!("Send error");
+                        return;
+                    }
+                }
+                Err(e) => {
+                    warn!("Read error: {}", e);
+                    return;
+                }
+            }
         }
     });
 
@@ -40,11 +47,13 @@ pub fn async_stdin_until(delimiter: u8) -> AsyncReader {
 pub fn async_stdin() -> AsyncReader {
     let (send, recv) = mpsc::channel();
 
-    thread::spawn(move || for i in get_tty().unwrap().bytes() {
-                      if send.send(i).is_err() {
-                          return;
-                      }
-                  });
+    thread::spawn(move || {
+        for i in get_tty().unwrap().bytes() {
+            if send.send(i).is_err() {
+                return;
+            }
+        }
+    });
 
     AsyncReader { recv: recv }
 }
@@ -80,7 +89,10 @@ impl Read for AsyncReader {
                     total += 1;
                 }
                 Ok(Err(e)) => return Err(e),
-                Err(_) => break,
+                Err(e) => {
+                    warn!("Receive error {}", e);
+                    break;
+                }
             }
         }
 

--- a/src/event.rs
+++ b/src/event.rs
@@ -110,7 +110,10 @@ where
         try_parse_event(item, &mut iter)
     };
     result
-        .or(Ok(Event::Unsupported(buf.clone())))
+        .or_else(|err| {
+            warn!("Event parse error: {}", err);
+            Ok(Event::Unsupported(buf.clone()))
+        })
         .map(|e| (e, buf))
 }
 

--- a/src/event.rs
+++ b/src/event.rs
@@ -114,7 +114,10 @@ where
             warn!("Event parse error: {}", err);
             Ok(Event::Unsupported(buf.clone()))
         })
-        .map(|e| (e, buf))
+        .map(|e| {
+            debug!("Event: {:?}", e);
+            (e, buf)
+        })
 }
 
 /// Parse an Event from `item` and possibly subsequent bytes through `iter`.

--- a/src/event.rs
+++ b/src/event.rs
@@ -233,16 +233,19 @@ where
 
             Event::Mouse(event)
         }
-        Some(Ok(c @ b'0'...b'9')) => {
+        Some(Ok(mut c @ b'0'...b'9')) => {
             // Numbered escape code.
             let mut buf = Vec::new();
             buf.push(c);
-            let mut c = iter.next().unwrap().unwrap();
             // The final byte of a CSI sequence can be in the range 64-126, so
             // let's keep reading anything else.
-            while c < 64 || c > 126 {
-                buf.push(c);
-                c = iter.next().unwrap().unwrap();
+            while let Some(n) = iter.next() {
+                c = n?;
+                if c < 64 || c > 126 {
+                    buf.push(c);
+                } else {
+                    break;
+                }
             }
 
             match c {

--- a/src/event.rs
+++ b/src/event.rs
@@ -98,30 +98,31 @@ pub enum Key {
 
 /// Parse an Event from `item` and possibly subsequent bytes through `iter`.
 pub fn parse_event<I>(item: u8, iter: &mut I) -> Result<Event, Error>
-    where I: Iterator<Item = Result<u8, Error>>
+where
+    I: Iterator<Item = Result<u8, Error>>,
 {
     let error = Error::new(ErrorKind::Other, "Could not parse an event");
     match item {
         b'\x1B' => {
             // This is an escape character, leading a control sequence.
             Ok(match iter.next() {
-                   Some(Ok(b'O')) => {
-                match iter.next() {
-                    // F1-F4
-                    Some(Ok(val @ b'P'...b'S')) => Event::Key(Key::F(1 + val - b'P')),
-                    _ => return Err(error),
+                Some(Ok(b'O')) => {
+                    match iter.next() {
+                        // F1-F4
+                        Some(Ok(val @ b'P'...b'S')) => Event::Key(Key::F(1 + val - b'P')),
+                        _ => return Err(error),
+                    }
                 }
-            }
-                   Some(Ok(b'[')) => {
-                // This is a CSI sequence.
-                parse_csi(iter).ok_or(error)?
-            }
-                   Some(Ok(c)) => {
-                let ch = parse_utf8_char(c, iter);
-                Event::Key(Key::Alt(try!(ch)))
-            }
-                   Some(Err(_)) | None => return Err(error),
-               })
+                Some(Ok(b'[')) => {
+                    // This is a CSI sequence.
+                    parse_csi(iter).ok_or(error)?
+                }
+                Some(Ok(c)) => {
+                    let ch = parse_utf8_char(c, iter);
+                    Event::Key(Key::Alt(try!(ch)))
+                }
+                Some(Err(_)) | None => return Err(error),
+            })
         }
         b'\n' | b'\r' => Ok(Event::Key(Key::Char('\n'))),
         b'\t' => Ok(Event::Key(Key::Char('\t'))),
@@ -129,12 +130,10 @@ pub fn parse_event<I>(item: u8, iter: &mut I) -> Result<Event, Error>
         c @ b'\x01'...b'\x1A' => Ok(Event::Key(Key::Ctrl((c as u8 - 0x1 + b'a') as char))),
         c @ b'\x1C'...b'\x1F' => Ok(Event::Key(Key::Ctrl((c as u8 - 0x1C + b'4') as char))),
         b'\0' => Ok(Event::Key(Key::Null)),
-        c => {
-            Ok({
-                   let ch = parse_utf8_char(c, iter);
-                   Event::Key(Key::Char(try!(ch)))
-               })
-        }
+        c => Ok({
+            let ch = parse_utf8_char(c, iter);
+            Event::Key(Key::Char(try!(ch)))
+        }),
     }
 }
 
@@ -142,178 +141,173 @@ pub fn parse_event<I>(item: u8, iter: &mut I) -> Result<Event, Error>
 ///
 /// Returns None if an unrecognized sequence is found.
 fn parse_csi<I>(iter: &mut I) -> Option<Event>
-    where I: Iterator<Item = Result<u8, Error>>
+where
+    I: Iterator<Item = Result<u8, Error>>,
 {
     Some(match iter.next() {
-             Some(Ok(b'[')) => match iter.next() {
-                 Some(Ok(val @ b'A'...b'E')) => Event::Key(Key::F(1 + val - b'A')),
-                 _ => return None,
-             },
-             Some(Ok(b'D')) => Event::Key(Key::Left),
-             Some(Ok(b'C')) => Event::Key(Key::Right),
-             Some(Ok(b'A')) => Event::Key(Key::Up),
-             Some(Ok(b'B')) => Event::Key(Key::Down),
-             Some(Ok(b'H')) => Event::Key(Key::Home),
-             Some(Ok(b'F')) => Event::Key(Key::End),
-             Some(Ok(b'M')) => {
-        // X10 emulation mouse encoding: ESC [ CB Cx Cy (6 characters only).
-        let mut next = || iter.next().unwrap().unwrap();
-
-        let cb = next() as i8 - 32;
-        // (1, 1) are the coords for upper left.
-        let cx = next().saturating_sub(32) as u16;
-        let cy = next().saturating_sub(32) as u16;
-        Event::Mouse(match cb & 0b11 {
-                         0 => {
-                             if cb & 0x40 != 0 {
-                                 MouseEvent::Press(MouseButton::WheelUp, cx, cy)
-                             } else {
-                                 MouseEvent::Press(MouseButton::Left, cx, cy)
-                             }
-                         }
-                         1 => {
-                             if cb & 0x40 != 0 {
-                                 MouseEvent::Press(MouseButton::WheelDown, cx, cy)
-                             } else {
-                                 MouseEvent::Press(MouseButton::Middle, cx, cy)
-                             }
-                         }
-                         2 => MouseEvent::Press(MouseButton::Right, cx, cy),
-                         3 => MouseEvent::Release(cx, cy),
-                         _ => return None,
-                     })
-    }
-             Some(Ok(b'<')) => {
-        // xterm mouse encoding:
-        // ESC [ < Cb ; Cx ; Cy (;) (M or m)
-        let mut buf = Vec::new();
-        let mut c = iter.next().unwrap().unwrap();
-        while match c {
-                  b'm' | b'M' => false,
-                  _ => true,
-              } {
-            buf.push(c);
-            c = iter.next().unwrap().unwrap();
-        }
-        let str_buf = String::from_utf8(buf).unwrap();
-        let nums = &mut str_buf.split(';');
-
-        let cb = nums.next()
-            .unwrap()
-            .parse::<u16>()
-            .unwrap();
-        let cx = nums.next()
-            .unwrap()
-            .parse::<u16>()
-            .unwrap();
-        let cy = nums.next()
-            .unwrap()
-            .parse::<u16>()
-            .unwrap();
-
-        let event = match cb {
-            0...2 | 64...65 => {
-                let button = match cb {
-                    0 => MouseButton::Left,
-                    1 => MouseButton::Middle,
-                    2 => MouseButton::Right,
-                    64 => MouseButton::WheelUp,
-                    65 => MouseButton::WheelDown,
-                    _ => unreachable!(),
-                };
-                match c {
-                    b'M' => MouseEvent::Press(button, cx, cy),
-                    b'm' => MouseEvent::Release(cx, cy),
-                    _ => return None,
-                }
-            }
-            32 => MouseEvent::Hold(cx, cy),
-            3 => MouseEvent::Release(cx, cy),
+        Some(Ok(b'[')) => match iter.next() {
+            Some(Ok(val @ b'A'...b'E')) => Event::Key(Key::F(1 + val - b'A')),
             _ => return None,
-        };
+        },
+        Some(Ok(b'D')) => Event::Key(Key::Left),
+        Some(Ok(b'C')) => Event::Key(Key::Right),
+        Some(Ok(b'A')) => Event::Key(Key::Up),
+        Some(Ok(b'B')) => Event::Key(Key::Down),
+        Some(Ok(b'H')) => Event::Key(Key::Home),
+        Some(Ok(b'F')) => Event::Key(Key::End),
+        Some(Ok(b'M')) => {
+            // X10 emulation mouse encoding: ESC [ CB Cx Cy (6 characters only).
+            let mut next = || iter.next().unwrap().unwrap();
 
-        Event::Mouse(event)
-    }
-             Some(Ok(c @ b'0'...b'9')) => {
-        // Numbered escape code.
-        let mut buf = Vec::new();
-        buf.push(c);
-        let mut c = iter.next().unwrap().unwrap();
-        // The final byte of a CSI sequence can be in the range 64-126, so
-        // let's keep reading anything else.
-        while c < 64 || c > 126 {
+            let cb = next() as i8 - 32;
+            // (1, 1) are the coords for upper left.
+            let cx = next().saturating_sub(32) as u16;
+            let cy = next().saturating_sub(32) as u16;
+            Event::Mouse(match cb & 0b11 {
+                0 => {
+                    if cb & 0x40 != 0 {
+                        MouseEvent::Press(MouseButton::WheelUp, cx, cy)
+                    } else {
+                        MouseEvent::Press(MouseButton::Left, cx, cy)
+                    }
+                }
+                1 => {
+                    if cb & 0x40 != 0 {
+                        MouseEvent::Press(MouseButton::WheelDown, cx, cy)
+                    } else {
+                        MouseEvent::Press(MouseButton::Middle, cx, cy)
+                    }
+                }
+                2 => MouseEvent::Press(MouseButton::Right, cx, cy),
+                3 => MouseEvent::Release(cx, cy),
+                _ => return None,
+            })
+        }
+        Some(Ok(b'<')) => {
+            // xterm mouse encoding:
+            // ESC [ < Cb ; Cx ; Cy (;) (M or m)
+            let mut buf = Vec::new();
+            let mut c = iter.next().unwrap().unwrap();
+            while match c {
+                b'm' | b'M' => false,
+                _ => true,
+            } {
+                buf.push(c);
+                c = iter.next().unwrap().unwrap();
+            }
+            let str_buf = String::from_utf8(buf).unwrap();
+            let nums = &mut str_buf.split(';');
+
+            let cb = nums.next().unwrap().parse::<u16>().unwrap();
+            let cx = nums.next().unwrap().parse::<u16>().unwrap();
+            let cy = nums.next().unwrap().parse::<u16>().unwrap();
+
+            let event = match cb {
+                0...2 | 64...65 => {
+                    let button = match cb {
+                        0 => MouseButton::Left,
+                        1 => MouseButton::Middle,
+                        2 => MouseButton::Right,
+                        64 => MouseButton::WheelUp,
+                        65 => MouseButton::WheelDown,
+                        _ => unreachable!(),
+                    };
+                    match c {
+                        b'M' => MouseEvent::Press(button, cx, cy),
+                        b'm' => MouseEvent::Release(cx, cy),
+                        _ => return None,
+                    }
+                }
+                32 => MouseEvent::Hold(cx, cy),
+                3 => MouseEvent::Release(cx, cy),
+                _ => return None,
+            };
+
+            Event::Mouse(event)
+        }
+        Some(Ok(c @ b'0'...b'9')) => {
+            // Numbered escape code.
+            let mut buf = Vec::new();
             buf.push(c);
-            c = iter.next().unwrap().unwrap();
-        }
-
-        match c {
-            // rxvt mouse encoding:
-            // ESC [ Cb ; Cx ; Cy ; M
-            b'M' => {
-                let str_buf = String::from_utf8(buf).unwrap();
-
-                let nums: Vec<u16> = str_buf.split(';').map(|n| n.parse().unwrap()).collect();
-
-                let cb = nums[0];
-                let cx = nums[1];
-                let cy = nums[2];
-
-                let event = match cb {
-                    32 => MouseEvent::Press(MouseButton::Left, cx, cy),
-                    33 => MouseEvent::Press(MouseButton::Middle, cx, cy),
-                    34 => MouseEvent::Press(MouseButton::Right, cx, cy),
-                    35 => MouseEvent::Release(cx, cy),
-                    64 => MouseEvent::Hold(cx, cy),
-                    96 | 97 => MouseEvent::Press(MouseButton::WheelUp, cx, cy),
-                    _ => return None,
-                };
-
-                Event::Mouse(event)
+            let mut c = iter.next().unwrap().unwrap();
+            // The final byte of a CSI sequence can be in the range 64-126, so
+            // let's keep reading anything else.
+            while c < 64 || c > 126 {
+                buf.push(c);
+                c = iter.next().unwrap().unwrap();
             }
-            // Special key code.
-            b'~' => {
-                let str_buf = String::from_utf8(buf).unwrap();
 
-                // This CSI sequence can be a list of semicolon-separated
-                // numbers.
-                let nums: Vec<u8> = str_buf.split(';').map(|n| n.parse().unwrap()).collect();
+            match c {
+                // rxvt mouse encoding:
+                // ESC [ Cb ; Cx ; Cy ; M
+                b'M' => {
+                    let str_buf = String::from_utf8(buf).unwrap();
 
-                if nums.is_empty() {
-                    return None;
+                    let nums: Vec<u16> = str_buf.split(';').map(|n| n.parse().unwrap()).collect();
+
+                    let cb = nums[0];
+                    let cx = nums[1];
+                    let cy = nums[2];
+
+                    let event = match cb {
+                        32 => MouseEvent::Press(MouseButton::Left, cx, cy),
+                        33 => MouseEvent::Press(MouseButton::Middle, cx, cy),
+                        34 => MouseEvent::Press(MouseButton::Right, cx, cy),
+                        35 => MouseEvent::Release(cx, cy),
+                        64 => MouseEvent::Hold(cx, cy),
+                        96 | 97 => MouseEvent::Press(MouseButton::WheelUp, cx, cy),
+                        _ => return None,
+                    };
+
+                    Event::Mouse(event)
                 }
+                // Special key code.
+                b'~' => {
+                    let str_buf = String::from_utf8(buf).unwrap();
 
-                // TODO: handle multiple values for key modififiers (ex: values
-                // [3, 2] means Shift+Delete)
-                if nums.len() > 1 {
-                    return None;
-                }
+                    // This CSI sequence can be a list of semicolon-separated
+                    // numbers.
+                    let nums: Vec<u8> = str_buf.split(';').map(|n| n.parse().unwrap()).collect();
 
-                match nums[0] {
-                    1 | 7 => Event::Key(Key::Home),
-                    2 => Event::Key(Key::Insert),
-                    3 => Event::Key(Key::Delete),
-                    4 | 8 => Event::Key(Key::End),
-                    5 => Event::Key(Key::PageUp),
-                    6 => Event::Key(Key::PageDown),
-                    v @ 11...15 => Event::Key(Key::F(v - 10)),
-                    v @ 17...21 => Event::Key(Key::F(v - 11)),
-                    v @ 23...24 => Event::Key(Key::F(v - 12)),
-                    _ => return None,
+                    if nums.is_empty() {
+                        return None;
+                    }
+
+                    // TODO: handle multiple values for key modififiers (ex: values
+                    // [3, 2] means Shift+Delete)
+                    if nums.len() > 1 {
+                        return None;
+                    }
+
+                    match nums[0] {
+                        1 | 7 => Event::Key(Key::Home),
+                        2 => Event::Key(Key::Insert),
+                        3 => Event::Key(Key::Delete),
+                        4 | 8 => Event::Key(Key::End),
+                        5 => Event::Key(Key::PageUp),
+                        6 => Event::Key(Key::PageDown),
+                        v @ 11...15 => Event::Key(Key::F(v - 10)),
+                        v @ 17...21 => Event::Key(Key::F(v - 11)),
+                        v @ 23...24 => Event::Key(Key::F(v - 12)),
+                        _ => return None,
+                    }
                 }
+                _ => return None,
             }
-            _ => return None,
         }
-    }
-             _ => return None,
-         })
-
+        _ => return None,
+    })
 }
 
 /// Parse `c` as either a single byte ASCII char or a variable size UTF-8 char.
 fn parse_utf8_char<I>(c: u8, iter: &mut I) -> Result<char, Error>
-    where I: Iterator<Item = Result<u8, Error>>
+where
+    I: Iterator<Item = Result<u8, Error>>,
 {
-    let error = Err(Error::new(ErrorKind::Other, "Input character is not valid UTF-8"));
+    let error = Err(Error::new(
+        ErrorKind::Other,
+        "Input character is not valid UTF-8",
+    ));
     if c.is_ascii() {
         Ok(c as char)
     } else {

--- a/src/input.rs
+++ b/src/input.rs
@@ -1,9 +1,10 @@
 //! User input.
 
+use event::parse_event;
 use std::io::{self, Read, Write};
 use std::ops;
 
-use event::{self, Event, Key};
+use event::{Event, Key};
 use raw::IntoRawMode;
 
 /// An iterator over input keys.
@@ -86,19 +87,6 @@ impl<R: Read> Iterator for EventsAndRaw<R> {
 
         Some(res)
     }
-}
-
-fn parse_event<I>(item: u8, iter: &mut I) -> Result<(Event, Vec<u8>), io::Error>
-    where I: Iterator<Item = Result<u8, io::Error>>
-{
-    let mut buf = vec![item];
-    let result = {
-        let mut iter = iter.inspect(|byte| if let &Ok(byte) = byte {
-                                        buf.push(byte);
-                                    });
-        event::parse_event(item, &mut iter)
-    };
-    result.or(Ok(Event::Unsupported(buf.clone()))).map(|e| (e, buf))
 }
 
 

--- a/src/input.rs
+++ b/src/input.rs
@@ -28,15 +28,17 @@ impl<R: Read> Iterator for Keys<R> {
 }
 
 /// An iterator over input events.
-pub struct Events<R>  {
-    inner: EventsAndRaw<R>
+pub struct Events<R> {
+    inner: EventsAndRaw<R>,
 }
 
 impl<R: Read> Iterator for Events<R> {
     type Item = Result<Event, io::Error>;
 
     fn next(&mut self) -> Option<Result<Event, io::Error>> {
-        self.inner.next().map(|tuple| tuple.map(|(event, _raw)| event))
+        self.inner
+            .next()
+            .map(|tuple| tuple.map(|(event, _raw)| event))
     }
 }
 
@@ -65,12 +67,10 @@ impl<R: Read> Iterator for EventsAndRaw<R> {
         let mut buf = [0u8; 2];
         let res = match source.read(&mut buf) {
             Ok(0) => return None,
-            Ok(1) => {
-                match buf[0] {
-                    b'\x1B' => Ok((Event::Key(Key::Esc), vec![b'\x1B'])),
-                    c => parse_event(c, &mut source.bytes()),
-                }
-            }
+            Ok(1) => match buf[0] {
+                b'\x1B' => Ok((Event::Key(Key::Esc), vec![b'\x1B'])),
+                c => parse_event(c, &mut source.bytes()),
+            },
             Ok(2) => {
                 let mut option_iter = &mut Some(buf[1]).into_iter();
                 let result = {
@@ -89,14 +89,17 @@ impl<R: Read> Iterator for EventsAndRaw<R> {
     }
 }
 
-
 /// Extension to `Read` trait.
 pub trait TermRead {
     /// An iterator over input events.
-    fn events(self) -> Events<Self> where Self: Sized;
+    fn events(self) -> Events<Self>
+    where
+        Self: Sized;
 
     /// An iterator over key inputs.
-    fn keys(self) -> Keys<Self> where Self: Sized;
+    fn keys(self) -> Keys<Self>
+    where
+        Self: Sized;
 
     /// Read a line.
     ///
@@ -114,15 +117,16 @@ pub trait TermRead {
     }
 }
 
-
 impl<R: Read + TermReadEventsAndRaw> TermRead for R {
     fn events(self) -> Events<Self> {
         Events {
-            inner: self.events_and_raw()
+            inner: self.events_and_raw(),
         }
     }
     fn keys(self) -> Keys<Self> {
-        Keys { iter: self.events() }
+        Keys {
+            iter: self.events(),
+        }
     }
 
     fn read_line(&mut self) -> io::Result<Option<String>> {
@@ -140,8 +144,8 @@ impl<R: Read + TermReadEventsAndRaw> TermRead for R {
             }
         }
 
-        let string = try!(String::from_utf8(buf)
-            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e)));
+        let string =
+            try!(String::from_utf8(buf).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e)));
         Ok(Some(string))
     }
 }
@@ -149,7 +153,9 @@ impl<R: Read + TermReadEventsAndRaw> TermRead for R {
 /// Extension to `TermRead` trait. A separate trait in order to maintain backwards compatibility.
 pub trait TermReadEventsAndRaw {
     /// An iterator over input events and the bytes that define them.
-    fn events_and_raw(self) -> EventsAndRaw<Self> where Self: Sized;
+    fn events_and_raw(self) -> EventsAndRaw<Self>
+    where
+        Self: Sized;
 }
 
 impl<R: Read> TermReadEventsAndRaw for R {
@@ -215,8 +221,8 @@ impl<W: Write> Write for MouseTerminal<W> {
 #[cfg(test)]
 mod test {
     use super::*;
+    use event::{Event, Key, MouseButton, MouseEvent};
     use std::io;
-    use event::{Key, Event, MouseEvent, MouseButton};
 
     #[test]
     fn test_keys() {
@@ -232,27 +238,38 @@ mod test {
 
     #[test]
     fn test_events() {
-        let mut i =
-            b"\x1B[\x00bc\x7F\x1B[D\
+        let mut i = b"\x1B[\x00bc\x7F\x1B[D\
                     \x1B[M\x00\x22\x24\x1B[<0;2;4;M\x1B[32;2;4M\x1B[<0;2;4;m\x1B[35;2;4Mb"
-                    .events();
+            .events();
 
-        assert_eq!(i.next().unwrap().unwrap(),
-                   Event::Unsupported(vec![0x1B, b'[', 0x00]));
+        assert_eq!(
+            i.next().unwrap().unwrap(),
+            Event::Unsupported(vec![0x1B, b'[', 0x00])
+        );
         assert_eq!(i.next().unwrap().unwrap(), Event::Key(Key::Char('b')));
         assert_eq!(i.next().unwrap().unwrap(), Event::Key(Key::Char('c')));
         assert_eq!(i.next().unwrap().unwrap(), Event::Key(Key::Backspace));
         assert_eq!(i.next().unwrap().unwrap(), Event::Key(Key::Left));
-        assert_eq!(i.next().unwrap().unwrap(),
-                   Event::Mouse(MouseEvent::Press(MouseButton::WheelUp, 2, 4)));
-        assert_eq!(i.next().unwrap().unwrap(),
-                   Event::Mouse(MouseEvent::Press(MouseButton::Left, 2, 4)));
-        assert_eq!(i.next().unwrap().unwrap(),
-                   Event::Mouse(MouseEvent::Press(MouseButton::Left, 2, 4)));
-        assert_eq!(i.next().unwrap().unwrap(),
-                   Event::Mouse(MouseEvent::Release(2, 4)));
-        assert_eq!(i.next().unwrap().unwrap(),
-                   Event::Mouse(MouseEvent::Release(2, 4)));
+        assert_eq!(
+            i.next().unwrap().unwrap(),
+            Event::Mouse(MouseEvent::Press(MouseButton::WheelUp, 2, 4))
+        );
+        assert_eq!(
+            i.next().unwrap().unwrap(),
+            Event::Mouse(MouseEvent::Press(MouseButton::Left, 2, 4))
+        );
+        assert_eq!(
+            i.next().unwrap().unwrap(),
+            Event::Mouse(MouseEvent::Press(MouseButton::Left, 2, 4))
+        );
+        assert_eq!(
+            i.next().unwrap().unwrap(),
+            Event::Mouse(MouseEvent::Release(2, 4))
+        );
+        assert_eq!(
+            i.next().unwrap().unwrap(),
+            Event::Mouse(MouseEvent::Release(2, 4))
+        );
         assert_eq!(i.next().unwrap().unwrap(), Event::Key(Key::Char('b')));
         assert!(i.next().is_none());
     }
@@ -263,25 +280,36 @@ mod test {
                     \x1B[M\x00\x22\x24\x1B[<0;2;4;M\x1B[32;2;4M\x1B[<0;2;4;m\x1B[35;2;4Mb";
         let mut output = Vec::<u8>::new();
         {
-            let mut i = input.events_and_raw().map(|res| res.unwrap())
-                .inspect(|&(_, ref raw)| { output.extend(raw); }).map(|(event, _)| event);
+            let mut i = input
+                .events_and_raw()
+                .map(|res| res.unwrap())
+                .inspect(|&(_, ref raw)| {
+                    output.extend(raw);
+                })
+                .map(|(event, _)| event);
 
-            assert_eq!(i.next().unwrap(),
-            Event::Unsupported(vec![0x1B, b'[', 0x00]));
+            assert_eq!(
+                i.next().unwrap(),
+                Event::Unsupported(vec![0x1B, b'[', 0x00])
+            );
             assert_eq!(i.next().unwrap(), Event::Key(Key::Char('b')));
             assert_eq!(i.next().unwrap(), Event::Key(Key::Char('c')));
             assert_eq!(i.next().unwrap(), Event::Key(Key::Backspace));
             assert_eq!(i.next().unwrap(), Event::Key(Key::Left));
-            assert_eq!(i.next().unwrap(),
-            Event::Mouse(MouseEvent::Press(MouseButton::WheelUp, 2, 4)));
-            assert_eq!(i.next().unwrap(),
-            Event::Mouse(MouseEvent::Press(MouseButton::Left, 2, 4)));
-            assert_eq!(i.next().unwrap(),
-            Event::Mouse(MouseEvent::Press(MouseButton::Left, 2, 4)));
-            assert_eq!(i.next().unwrap(),
-            Event::Mouse(MouseEvent::Release(2, 4)));
-            assert_eq!(i.next().unwrap(),
-            Event::Mouse(MouseEvent::Release(2, 4)));
+            assert_eq!(
+                i.next().unwrap(),
+                Event::Mouse(MouseEvent::Press(MouseButton::WheelUp, 2, 4))
+            );
+            assert_eq!(
+                i.next().unwrap(),
+                Event::Mouse(MouseEvent::Press(MouseButton::Left, 2, 4))
+            );
+            assert_eq!(
+                i.next().unwrap(),
+                Event::Mouse(MouseEvent::Press(MouseButton::Left, 2, 4))
+            );
+            assert_eq!(i.next().unwrap(), Event::Mouse(MouseEvent::Release(2, 4)));
+            assert_eq!(i.next().unwrap(), Event::Mouse(MouseEvent::Release(2, 4)));
             assert_eq!(i.next().unwrap(), Event::Key(Key::Char('b')));
             assert!(i.next().is_none());
         }
@@ -298,7 +326,7 @@ mod test {
 
         let mut st = b"\x1B[11~\x1B[12~\x1B[13~\x1B[14~\x1B[15~\
         \x1B[17~\x1B[18~\x1B[19~\x1B[20~\x1B[21~\x1B[23~\x1B[24~"
-                .keys();
+            .keys();
         for i in 1..13 {
             assert_eq!(st.next().unwrap().unwrap(), Key::F(i));
         }
@@ -353,18 +381,26 @@ mod test {
 
     #[test]
     fn test_backspace() {
-        line_match("this is the\x7f first\x7f\x7f test",
-                   Some("this is th fir test"));
-        line_match("this is the seco\x7fnd test\x7f",
-                   Some("this is the secnd tes"));
+        line_match(
+            "this is the\x7f first\x7f\x7f test",
+            Some("this is th fir test"),
+        );
+        line_match(
+            "this is the seco\x7fnd test\x7f",
+            Some("this is the secnd tes"),
+        );
     }
 
     #[test]
     fn test_end() {
-        line_match("abc\nhttps://www.youtube.com/watch?v=dQw4w9WgXcQ",
-                   Some("abc"));
-        line_match("hello\rhttps://www.youtube.com/watch?v=yPYZpwSpKmA",
-                   Some("hello"));
+        line_match(
+            "abc\nhttps://www.youtube.com/watch?v=dQw4w9WgXcQ",
+            Some("abc"),
+        );
+        line_match(
+            "hello\rhttps://www.youtube.com/watch?v=yPYZpwSpKmA",
+            Some("hello"),
+        );
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,9 @@
 
 extern crate numtoa;
 
+#[macro_use]
+extern crate log;
+
 #[cfg(target_os = "redox")]
 #[path="sys/redox/mod.rs"]
 mod sys;


### PR DESCRIPTION
Problem: With the MouseTerminal, press mouse and drag the pointer outside of the terminal window and fiddle with it a lot => panic:
```

thread 'main' panicked at 'called `Option::unwrap()` on a `None` value', libcore/option.rs:345:21
stack backtrace:
   0: std::sys::unix::backtrace::tracing::imp::unwind_backtrace
             at libstd/sys/unix/backtrace/tracing/gcc_s.rs:49
   1: std::sys_common::backtrace::print
             at libstd/sys_common/backtrace.rs:71
             at libstd/sys_common/backtrace.rs:59
   2: std::panicking::default_hook::{{closure}}
             at libstd/panicking.rs:211
   3: std::panicking::default_hook
             at libstd/panicking.rs:227
   4: std::panicking::rust_panic_with_hook
             at libstd/panicking.rs:511
   5: std::panicking::continue_panic_fmt
             at libstd/panicking.rs:426
   6: rust_begin_unwind
             at libstd/panicking.rs:337
   7: core::panicking::panic_fmt
             at libcore/panicking.rs:92
   8: core::panicking::panic
             at libcore/panicking.rs:53
   9: <core::option::Option<T>>::unwrap
             at /checkout/src/libcore/macros.rs:20
  10: termion::event::parse_csi::{{closure}}
             at ~/.cargo/registry/src/github.com-1ecc6299db9ec823/termion-1.5.1/src/event.rs:161
  11: termion::event::parse_csi
             at ~/.cargo/registry/src/github.com-1ecc6299db9ec823/termion-1.5.1/src/event.rs:166
  12: termion::event::parse_event
             at ~/.cargo/registry/src/github.com-1ecc6299db9ec823/termion-1.5.1/src/event.rs:118
  13: termion::input::parse_event
             at ~/.cargo/registry/src/github.com-1ecc6299db9ec823/termion-1.5.1/src/input.rs:99
  14: <termion::input::EventsAndRaw<R> as core::iter::iterator::Iterator>::next
             at ~/.cargo/registry/src/github.com-1ecc6299db9ec823/termion-1.5.1/src/input.rs:77
  15: <termion::input::Events<R> as core::iter::iterator::Iterator>::next
             at ~/.cargo/registry/src/github.com-1ecc6299db9ec823/termion-1.5.1/src/input.rs:38
  16: two::ui::grinui::GrinUI::process
             at src/ui/grinui.rs:59
  17: two::ui::grinui::GrinUI::react_once
             at src/ui/grinui.rs:54
  18: two::ui::grin::Grin::wait
             at src/ui/grin.rs:63
  19: two::main::{{closure}}
             at src/main.rs:23
  20: <core::result::Result<T, E>>::and_then
             at /checkout/src/libcore/result.rs:621
  21: two::main
             at src/main.rs:22
  22: std::rt::lang_start::{{closure}}
             at /checkout/src/libstd/rt.rs:74
  23: std::panicking::try::do_call
             at libstd/rt.rs:59
             at libstd/panicking.rs:310
  24: __rust_maybe_catch_panic
             at libpanic_unwind/lib.rs:105
  25: std::rt::lang_start_internal
             at libstd/panicking.rs:289
             at libstd/panic.rs:392
             at libstd/rt.rs:58
  26: std::rt::lang_start
             at /checkout/src/libstd/rt.rs:74
  27: main
  28: __libc_start_main
  29: _start
```

To help others trying to crack on event issues I've added some logging. Feel free to remove that if not welcome. I'm still thinking what to do with the lone ESC event:

> 2019-01-27T19:11:34+01:00 - DEBUG - Event: Mouse(Press(Left, 4, 47))
> 2019-01-27T19:11:34+01:00 - DEBUG - Event: Mouse(Press(Left, 1, 47))
> 2019-01-27T19:11:34+01:00 - DEBUG - Event: lone ESC
> 2019-01-27T19:11:34+01:00 - DEBUG - Event: Key(Char('['))
> 2019-01-27T19:11:34+01:00 - DEBUG - Leftover: 77
> 2019-01-27T19:11:34+01:00 - DEBUG - Event: Key(Char('M'))
> 2019-01-27T19:11:34+01:00 - DEBUG - Event: Key(Char('@'))
> 2019-01-27T19:11:34+01:00 - DEBUG - Leftover: 33
> 2019-01-27T19:11:34+01:00 - DEBUG - Event: Key(Char('!'))
> 2019-01-27T19:11:34+01:00 - DEBUG - Event: Key(Char('O'))
> 2019-01-27T19:11:34+01:00 - DEBUG - Event: Mouse(Press(Left, 1, 48))
> 2019-01-27T19:11:34+01:00 - DEBUG - Event: Mouse(Press(Left, 1, 49))