### PR TITLE
Make Color extend Debug

### DIFF
--- a/src/color.rs
+++ b/src/color.rs
@@ -18,10 +18,11 @@ use std::io::{self, Write, Read};
 use std::time::{SystemTime, Duration};
 use async::async_stdin;
 use std::env;
+use std::fmt::Debug;
 use numtoa::NumToA;
 
 /// A terminal color.
-pub trait Color {
+pub trait Color: Debug {
     /// Write the foreground version of this color.
     fn write_fg(&self, f: &mut fmt::Formatter) -> fmt::Result;
     /// Write the background version of this color.


### PR DESCRIPTION
Currently, all colors implement the Debug trait separately, but the Color trait does not extend Debug. This makes it impossible to write generic code that exploits the Debug trait implemented by Colors. 