### PR TITLE
parse_event now distinguishes between invalid and incomplete input

### DIFF
--- a/src/event.rs
+++ b/src/event.rs
@@ -98,30 +98,34 @@ pub enum Key {
 
 /// Parse an Event from `item` and possibly subsequent bytes through `iter`.
 pub fn parse_event<I>(item: u8, iter: &mut I) -> Result<Event, Error>
-    where I: Iterator<Item = Result<u8, Error>>
+where
+    I: Iterator<Item = Result<u8, Error>>,
 {
     let error = Error::new(ErrorKind::Other, "Could not parse an event");
+    let err_would_block = Error::new(ErrorKind::WouldBlock, "Not enough input");
     match item {
         b'\x1B' => {
             // This is an escape character, leading a control sequence.
             Ok(match iter.next() {
-                   Some(Ok(b'O')) => {
-                match iter.next() {
-                    // F1-F4
-                    Some(Ok(val @ b'P'...b'S')) => Event::Key(Key::F(1 + val - b'P')),
-                    _ => return Err(error),
+                Some(Ok(b'O')) => {
+                    match iter.next() {
+                        // F1-F4
+                        Some(Ok(val @ b'P'...b'S')) => Event::Key(Key::F(1 + val - b'P')),
+                        None => return Err(err_would_block),
+                        _ => return Err(error),
+                    }
                 }
-            }
-                   Some(Ok(b'[')) => {
-                // This is a CSI sequence.
-                parse_csi(iter).ok_or(error)?
-            }
-                   Some(Ok(c)) => {
-                let ch = parse_utf8_char(c, iter);
-                Event::Key(Key::Alt(try!(ch)))
-            }
-                   Some(Err(_)) | None => return Err(error),
-               })
+                Some(Ok(b'[')) => {
+                    // This is a CSI sequence.
+                    parse_csi(iter).ok_or(error)?
+                }
+                Some(Ok(c)) => {
+                    let ch = parse_utf8_char(c, iter);
+                    Event::Key(Key::Alt(try!(ch)))
+                }
+                Some(Err(_)) => return Err(error),
+                None => return Err(err_would_block),
+            })
         }
         b'\n' | b'\r' => Ok(Event::Key(Key::Char('\n'))),
         b'\t' => Ok(Event::Key(Key::Char('\t'))),
@@ -129,12 +133,10 @@ pub fn parse_event<I>(item: u8, iter: &mut I) -> Result<Event, Error>
         c @ b'\x01'...b'\x1A' => Ok(Event::Key(Key::Ctrl((c as u8 - 0x1 + b'a') as char))),
         c @ b'\x1C'...b'\x1F' => Ok(Event::Key(Key::Ctrl((c as u8 - 0x1C + b'4') as char))),
         b'\0' => Ok(Event::Key(Key::Null)),
-        c => {
-            Ok({
-                   let ch = parse_utf8_char(c, iter);
-                   Event::Key(Key::Char(try!(ch)))
-               })
-        }
+        c => Ok({
+            let ch = parse_utf8_char(c, iter);
+            Event::Key(Key::Char(try!(ch)))
+        }),
     }
 }
 
@@ -142,178 +144,173 @@ pub fn parse_event<I>(item: u8, iter: &mut I) -> Result<Event, Error>
 ///
 /// Returns None if an unrecognized sequence is found.
 fn parse_csi<I>(iter: &mut I) -> Option<Event>
-    where I: Iterator<Item = Result<u8, Error>>
+where
+    I: Iterator<Item = Result<u8, Error>>,
 {
     Some(match iter.next() {
-             Some(Ok(b'[')) => match iter.next() {
-                 Some(Ok(val @ b'A'...b'E')) => Event::Key(Key::F(1 + val - b'A')),
-                 _ => return None,
-             },
-             Some(Ok(b'D')) => Event::Key(Key::Left),
-             Some(Ok(b'C')) => Event::Key(Key::Right),
-             Some(Ok(b'A')) => Event::Key(Key::Up),
-             Some(Ok(b'B')) => Event::Key(Key::Down),
-             Some(Ok(b'H')) => Event::Key(Key::Home),
-             Some(Ok(b'F')) => Event::Key(Key::End),
-             Some(Ok(b'M')) => {
-        // X10 emulation mouse encoding: ESC [ CB Cx Cy (6 characters only).
-        let mut next = || iter.next().unwrap().unwrap();
-
-        let cb = next() as i8 - 32;
-        // (1, 1) are the coords for upper left.
-        let cx = next().saturating_sub(32) as u16;
-        let cy = next().saturating_sub(32) as u16;
-        Event::Mouse(match cb & 0b11 {
-                         0 => {
-                             if cb & 0x40 != 0 {
-                                 MouseEvent::Press(MouseButton::WheelUp, cx, cy)
-                             } else {
-                                 MouseEvent::Press(MouseButton::Left, cx, cy)
-                             }
-                         }
-                         1 => {
-                             if cb & 0x40 != 0 {
-                                 MouseEvent::Press(MouseButton::WheelDown, cx, cy)
-                             } else {
-                                 MouseEvent::Press(MouseButton::Middle, cx, cy)
-                             }
-                         }
-                         2 => MouseEvent::Press(MouseButton::Right, cx, cy),
-                         3 => MouseEvent::Release(cx, cy),
-                         _ => return None,
-                     })
-    }
-             Some(Ok(b'<')) => {
-        // xterm mouse encoding:
-        // ESC [ < Cb ; Cx ; Cy (;) (M or m)
-        let mut buf = Vec::new();
-        let mut c = iter.next().unwrap().unwrap();
-        while match c {
-                  b'm' | b'M' => false,
-                  _ => true,
-              } {
-            buf.push(c);
-            c = iter.next().unwrap().unwrap();
-        }
-        let str_buf = String::from_utf8(buf).unwrap();
-        let nums = &mut str_buf.split(';');
-
-        let cb = nums.next()
-            .unwrap()
-            .parse::<u16>()
-            .unwrap();
-        let cx = nums.next()
-            .unwrap()
-            .parse::<u16>()
-            .unwrap();
-        let cy = nums.next()
-            .unwrap()
-            .parse::<u16>()
-            .unwrap();
-
-        let event = match cb {
-            0...2 | 64...65 => {
-                let button = match cb {
-                    0 => MouseButton::Left,
-                    1 => MouseButton::Middle,
-                    2 => MouseButton::Right,
-                    64 => MouseButton::WheelUp,
-                    65 => MouseButton::WheelDown,
-                    _ => unreachable!(),
-                };
-                match c {
-                    b'M' => MouseEvent::Press(button, cx, cy),
-                    b'm' => MouseEvent::Release(cx, cy),
-                    _ => return None,
-                }
-            }
-            32 => MouseEvent::Hold(cx, cy),
-            3 => MouseEvent::Release(cx, cy),
+        Some(Ok(b'[')) => match iter.next() {
+            Some(Ok(val @ b'A'...b'E')) => Event::Key(Key::F(1 + val - b'A')),
             _ => return None,
-        };
+        },
+        Some(Ok(b'D')) => Event::Key(Key::Left),
+        Some(Ok(b'C')) => Event::Key(Key::Right),
+        Some(Ok(b'A')) => Event::Key(Key::Up),
+        Some(Ok(b'B')) => Event::Key(Key::Down),
+        Some(Ok(b'H')) => Event::Key(Key::Home),
+        Some(Ok(b'F')) => Event::Key(Key::End),
+        Some(Ok(b'M')) => {
+            // X10 emulation mouse encoding: ESC [ CB Cx Cy (6 characters only).
+            let mut next = || iter.next().unwrap().unwrap();
 
-        Event::Mouse(event)
-    }
-             Some(Ok(c @ b'0'...b'9')) => {
-        // Numbered escape code.
-        let mut buf = Vec::new();
-        buf.push(c);
-        let mut c = iter.next().unwrap().unwrap();
-        // The final byte of a CSI sequence can be in the range 64-126, so
-        // let's keep reading anything else.
-        while c < 64 || c > 126 {
+            let cb = next() as i8 - 32;
+            // (1, 1) are the coords for upper left.
+            let cx = next().saturating_sub(32) as u16;
+            let cy = next().saturating_sub(32) as u16;
+            Event::Mouse(match cb & 0b11 {
+                0 => {
+                    if cb & 0x40 != 0 {
+                        MouseEvent::Press(MouseButton::WheelUp, cx, cy)
+                    } else {
+                        MouseEvent::Press(MouseButton::Left, cx, cy)
+                    }
+                }
+                1 => {
+                    if cb & 0x40 != 0 {
+                        MouseEvent::Press(MouseButton::WheelDown, cx, cy)
+                    } else {
+                        MouseEvent::Press(MouseButton::Middle, cx, cy)
+                    }
+                }
+                2 => MouseEvent::Press(MouseButton::Right, cx, cy),
+                3 => MouseEvent::Release(cx, cy),
+                _ => return None,
+            })
+        }
+        Some(Ok(b'<')) => {
+            // xterm mouse encoding:
+            // ESC [ < Cb ; Cx ; Cy (;) (M or m)
+            let mut buf = Vec::new();
+            let mut c = iter.next().unwrap().unwrap();
+            while match c {
+                b'm' | b'M' => false,
+                _ => true,
+            } {
+                buf.push(c);
+                c = iter.next().unwrap().unwrap();
+            }
+            let str_buf = String::from_utf8(buf).unwrap();
+            let nums = &mut str_buf.split(';');
+
+            let cb = nums.next().unwrap().parse::<u16>().unwrap();
+            let cx = nums.next().unwrap().parse::<u16>().unwrap();
+            let cy = nums.next().unwrap().parse::<u16>().unwrap();
+
+            let event = match cb {
+                0...2 | 64...65 => {
+                    let button = match cb {
+                        0 => MouseButton::Left,
+                        1 => MouseButton::Middle,
+                        2 => MouseButton::Right,
+                        64 => MouseButton::WheelUp,
+                        65 => MouseButton::WheelDown,
+                        _ => unreachable!(),
+                    };
+                    match c {
+                        b'M' => MouseEvent::Press(button, cx, cy),
+                        b'm' => MouseEvent::Release(cx, cy),
+                        _ => return None,
+                    }
+                }
+                32 => MouseEvent::Hold(cx, cy),
+                3 => MouseEvent::Release(cx, cy),
+                _ => return None,
+            };
+
+            Event::Mouse(event)
+        }
+        Some(Ok(c @ b'0'...b'9')) => {
+            // Numbered escape code.
+            let mut buf = Vec::new();
             buf.push(c);
-            c = iter.next().unwrap().unwrap();
-        }
-
-        match c {
-            // rxvt mouse encoding:
-            // ESC [ Cb ; Cx ; Cy ; M
-            b'M' => {
-                let str_buf = String::from_utf8(buf).unwrap();
-
-                let nums: Vec<u16> = str_buf.split(';').map(|n| n.parse().unwrap()).collect();
-
-                let cb = nums[0];
-                let cx = nums[1];
-                let cy = nums[2];
-
-                let event = match cb {
-                    32 => MouseEvent::Press(MouseButton::Left, cx, cy),
-                    33 => MouseEvent::Press(MouseButton::Middle, cx, cy),
-                    34 => MouseEvent::Press(MouseButton::Right, cx, cy),
-                    35 => MouseEvent::Release(cx, cy),
-                    64 => MouseEvent::Hold(cx, cy),
-                    96 | 97 => MouseEvent::Press(MouseButton::WheelUp, cx, cy),
-                    _ => return None,
-                };
-
-                Event::Mouse(event)
+            let mut c = iter.next().unwrap().unwrap();
+            // The final byte of a CSI sequence can be in the range 64-126, so
+            // let's keep reading anything else.
+            while c < 64 || c > 126 {
+                buf.push(c);
+                c = iter.next().unwrap().unwrap();
             }
-            // Special key code.
-            b'~' => {
-                let str_buf = String::from_utf8(buf).unwrap();
 
-                // This CSI sequence can be a list of semicolon-separated
-                // numbers.
-                let nums: Vec<u8> = str_buf.split(';').map(|n| n.parse().unwrap()).collect();
+            match c {
+                // rxvt mouse encoding:
+                // ESC [ Cb ; Cx ; Cy ; M
+                b'M' => {
+                    let str_buf = String::from_utf8(buf).unwrap();
 
-                if nums.is_empty() {
-                    return None;
+                    let nums: Vec<u16> = str_buf.split(';').map(|n| n.parse().unwrap()).collect();
+
+                    let cb = nums[0];
+                    let cx = nums[1];
+                    let cy = nums[2];
+
+                    let event = match cb {
+                        32 => MouseEvent::Press(MouseButton::Left, cx, cy),
+                        33 => MouseEvent::Press(MouseButton::Middle, cx, cy),
+                        34 => MouseEvent::Press(MouseButton::Right, cx, cy),
+                        35 => MouseEvent::Release(cx, cy),
+                        64 => MouseEvent::Hold(cx, cy),
+                        96 | 97 => MouseEvent::Press(MouseButton::WheelUp, cx, cy),
+                        _ => return None,
+                    };
+
+                    Event::Mouse(event)
                 }
+                // Special key code.
+                b'~' => {
+                    let str_buf = String::from_utf8(buf).unwrap();
 
-                // TODO: handle multiple values for key modififiers (ex: values
-                // [3, 2] means Shift+Delete)
-                if nums.len() > 1 {
-                    return None;
-                }
+                    // This CSI sequence can be a list of semicolon-separated
+                    // numbers.
+                    let nums: Vec<u8> = str_buf.split(';').map(|n| n.parse().unwrap()).collect();
 
-                match nums[0] {
-                    1 | 7 => Event::Key(Key::Home),
-                    2 => Event::Key(Key::Insert),
-                    3 => Event::Key(Key::Delete),
-                    4 | 8 => Event::Key(Key::End),
-                    5 => Event::Key(Key::PageUp),
-                    6 => Event::Key(Key::PageDown),
-                    v @ 11...15 => Event::Key(Key::F(v - 10)),
-                    v @ 17...21 => Event::Key(Key::F(v - 11)),
-                    v @ 23...24 => Event::Key(Key::F(v - 12)),
-                    _ => return None,
+                    if nums.is_empty() {
+                        return None;
+                    }
+
+                    // TODO: handle multiple values for key modififiers (ex: values
+                    // [3, 2] means Shift+Delete)
+                    if nums.len() > 1 {
+                        return None;
+                    }
+
+                    match nums[0] {
+                        1 | 7 => Event::Key(Key::Home),
+                        2 => Event::Key(Key::Insert),
+                        3 => Event::Key(Key::Delete),
+                        4 | 8 => Event::Key(Key::End),
+                        5 => Event::Key(Key::PageUp),
+                        6 => Event::Key(Key::PageDown),
+                        v @ 11...15 => Event::Key(Key::F(v - 10)),
+                        v @ 17...21 => Event::Key(Key::F(v - 11)),
+                        v @ 23...24 => Event::Key(Key::F(v - 12)),
+                        _ => return None,
+                    }
                 }
+                _ => return None,
             }
-            _ => return None,
         }
-    }
-             _ => return None,
-         })
-
+        _ => return None,
+    })
 }
 
 /// Parse `c` as either a single byte ASCII char or a variable size UTF-8 char.
 fn parse_utf8_char<I>(c: u8, iter: &mut I) -> Result<char, Error>
-    where I: Iterator<Item = Result<u8, Error>>
+where
+    I: Iterator<Item = Result<u8, Error>>,
 {
-    let error = Err(Error::new(ErrorKind::Other, "Input character is not valid UTF-8"));
+    let error = Err(Error::new(
+        ErrorKind::Other,
+        "Input character is not valid UTF-8",
+    ));
     if c.is_ascii() {
         Ok(c as char)
     } else {
@@ -331,6 +328,7 @@ fn parse_utf8_char<I>(c: u8, iter: &mut I) -> Result<char, Error>
                         return error;
                     }
                 }
+                None => return Err(Error::from(ErrorKind::WouldBlock)),
                 _ => return error,
             }
         }
@@ -347,4 +345,11 @@ fn test_parse_utf8() {
         let b = bytes.next().unwrap().unwrap();
         assert!(c == parse_utf8_char(b, bytes).unwrap());
     }
+}
+
+#[cfg(test)]
+#[test]
+fn test_parse_event_would_block() {
+    let result: Result<_, Error> = parse_event(b'\x1B', &mut std::iter::empty());
+    assert_eq!(ErrorKind::WouldBlock, result.unwrap_err().kind())
 }


### PR DESCRIPTION
When parsing an event, if input is expected and not available,
parse_event will return an Error with ErrorKind WouldBlock.
All other error conditions are unaffected.

I'm making a telnet frontend for termion, and this distinction will let me parse in a non-blocking fashion.