### PR TITLE
Handle timeout in the middle of cursor response

### DIFF
--- a/src/cursor.rs
+++ b/src/cursor.rs
@@ -151,7 +151,7 @@ impl<W: Write> DetectCursorPos for W {
             }
         }
 
-        if read_chars.is_empty() {
+        if read_chars.last() != Some(&delimiter) {
             return Err(Error::new(ErrorKind::Other, "Cursor position detection timed out."));
         }
 


### PR DESCRIPTION
The timeout could happen anywhere in the cursor position response code. This change makes sure that we actually have a valid response (the code below relies on that fact)

Note that I didn't actually run and test this code. In fact I just came across it on github while researching something related. Anyway, I have quite good confidence in the change.