### PR TITLE
Allow resetting cursor style to terminal default

### DIFF
--- a/src/cursor.rs
+++ b/src/cursor.rs
@@ -14,6 +14,7 @@ derive_csi_sequence!("Show the cursor.", Show, "?25h");
 derive_csi_sequence!("Restore the cursor.", Restore, "u");
 derive_csi_sequence!("Save the cursor.", Save, "s");
 
+derive_csi_sequence!("Change the cursor style to terminal default", DefaultStyle, "\x30 q");
 derive_csi_sequence!("Change the cursor style to blinking block", BlinkingBlock, "\x31 q");
 derive_csi_sequence!("Change the cursor style to steady block", SteadyBlock, "\x32 q");
 derive_csi_sequence!("Change the cursor style to blinking underline", BlinkingUnderline, "\x33 q");


### PR DESCRIPTION
This adds `cursor::DefaultStyle`, which will reset the cursor style back to the terminal default. The default is normally a block cursor, which is why this might seem to give the same results as `cursor::BlinkingBlock`. However, if you change the cursor style in the terminal settings (I tested with Gnome Terminal), then you will see an effect of this escape sequence.

This [Super User answer](https://superuser.com/a/1302503/22077) links to more documentation and discussion around this feature.