### PR TITLE
add illumos support

### DIFF
--- a/src/sys/unix/attr.rs
+++ b/src/sys/unix/attr.rs
@@ -18,12 +18,18 @@ pub fn set_terminal_attr(termios: &Termios) -> io::Result<()> {
     extern "C" {
         pub fn tcsetattr(fd: c_int, opt: c_int, termptr: *const Termios) -> c_int;
     }
-    cvt(unsafe { tcsetattr(1, 0, termios) }).and(Ok(()))
+    cvt(unsafe { tcsetattr(libc::STDOUT_FILENO, libc::TCSANOW, termios) }).and(Ok(()))
 }
 
+#[cfg(not(target_os = "illumos"))]
 pub fn raw_terminal_attr(termios: &mut Termios) {
     extern "C" {
         pub fn cfmakeraw(termptr: *mut Termios);
     }
     unsafe { cfmakeraw(termios) }
+}
+
+#[cfg(target_os = "illumos")]
+pub fn raw_terminal_attr(termios: &mut Termios) {
+    unsafe { libc::cfmakeraw(termios) }
 }


### PR DESCRIPTION
Everything pretty much works on illumos as-is, except for two issues:

* We do not currently have a system implementation of `cfmakeraw()`; see [illumos bug 1060](https://www.illumos.org/issues/1060).  There is, however, a compatibility implementation in the *libc* crate so we use that here.
* It seems like we're using `tcsetattr()` in `set_terminal_attr()` with a literal `0` for the `actions` argument; this appears to correspond to `TCSANOW` on Linux systems.  On illumos, this constant has a different value, so we should use the symbol from the *libc* crate here.