### PR TITLE
Add MouseButton in Hold and release event for some terminal.

### DIFF
--- a/examples/mouse.rs
+++ b/examples/mouse.rs
@@ -1,7 +1,7 @@
 extern crate termion;
 
 use termion::event::*;
-use termion::cursor::{self, DetectCursorPos};
+use termion::cursor;
 use termion::input::{TermRead, MouseTerminal};
 use termion::raw::IntoRawMode;
 use std::io::{self, Write};
@@ -23,16 +23,13 @@ fn main() {
             Event::Mouse(me) => {
                 match me {
                     MouseEvent::Press(_, a, b) |
-                    MouseEvent::Release(a, b) |
-                    MouseEvent::Hold(a, b) => {
-                        write!(stdout, "{}", cursor::Goto(a, b)).unwrap();
-                        let (x, y) = stdout.cursor_pos().unwrap();
+                    MouseEvent::Release(_, a, b) |
+                    MouseEvent::Hold(_, a, b) => {
                         write!(stdout,
-                               "{}{}Cursor is at: ({},{}){}",
+                               "{}{}Cursor is {:?}{}",
                                cursor::Goto(5, 5),
                                termion::clear::UntilNewline,
-                               x,
-                               y,
+                               me,
                                cursor::Goto(a, b))
                                 .unwrap();
                     }

--- a/src/event.rs
+++ b/src/event.rs
@@ -24,11 +24,11 @@ pub enum MouseEvent {
     /// A mouse button was released.
     ///
     /// The coordinates are one-based.
-    Release(u16, u16),
+    Release(Option<MouseButton>, u16, u16),
     /// A mouse button is held over the given coordinates.
     ///
     /// The coordinates are one-based.
-    Hold(u16, u16),
+    Hold(MouseButton, u16, u16),
 }
 
 /// A mouse button.
@@ -182,7 +182,7 @@ fn parse_csi<I>(iter: &mut I) -> Option<Event>
                              }
                          }
                          2 => MouseEvent::Press(MouseButton::Right, cx, cy),
-                         3 => MouseEvent::Release(cx, cy),
+                         3 => MouseEvent::Release(None, cx, cy),
                          _ => return None,
                      })
     }
@@ -226,12 +226,14 @@ fn parse_csi<I>(iter: &mut I) -> Option<Event>
                 };
                 match c {
                     b'M' => MouseEvent::Press(button, cx, cy),
-                    b'm' => MouseEvent::Release(cx, cy),
+                    b'm' => MouseEvent::Release(Some(button), cx, cy),
                     _ => return None,
                 }
             }
-            32 => MouseEvent::Hold(cx, cy),
-            3 => MouseEvent::Release(cx, cy),
+            32 => MouseEvent::Hold(MouseButton::Left, cx, cy),
+            33 => MouseEvent::Hold(MouseButton::Middle, cx, cy),
+            34 => MouseEvent::Hold(MouseButton::Right, cx, cy),
+            3 => MouseEvent::Release(None, cx, cy),
             _ => return None,
         };
 
@@ -265,8 +267,8 @@ fn parse_csi<I>(iter: &mut I) -> Option<Event>
                     32 => MouseEvent::Press(MouseButton::Left, cx, cy),
                     33 => MouseEvent::Press(MouseButton::Middle, cx, cy),
                     34 => MouseEvent::Press(MouseButton::Right, cx, cy),
-                    35 => MouseEvent::Release(cx, cy),
-                    64 => MouseEvent::Hold(cx, cy),
+                    35 => MouseEvent::Release(None, cx, cy),
+                    64 => MouseEvent::Hold(MouseButton::Left, cx, cy),
                     96 | 97 => MouseEvent::Press(MouseButton::WheelUp, cx, cy),
                     _ => return None,
                 };

--- a/src/input.rs
+++ b/src/input.rs
@@ -262,9 +262,9 @@ mod test {
         assert_eq!(i.next().unwrap().unwrap(),
                    Event::Mouse(MouseEvent::Press(MouseButton::Left, 2, 4)));
         assert_eq!(i.next().unwrap().unwrap(),
-                   Event::Mouse(MouseEvent::Release(2, 4)));
+                   Event::Mouse(MouseEvent::Release(Some(MouseButton::Left), 2, 4)));
         assert_eq!(i.next().unwrap().unwrap(),
-                   Event::Mouse(MouseEvent::Release(2, 4)));
+                   Event::Mouse(MouseEvent::Release(None, 2, 4)));
         assert_eq!(i.next().unwrap().unwrap(), Event::Key(Key::Char('b')));
         assert!(i.next().is_none());
     }
@@ -291,9 +291,9 @@ mod test {
             assert_eq!(i.next().unwrap(),
             Event::Mouse(MouseEvent::Press(MouseButton::Left, 2, 4)));
             assert_eq!(i.next().unwrap(),
-            Event::Mouse(MouseEvent::Release(2, 4)));
+            Event::Mouse(MouseEvent::Release(Some(MouseButton::Left), 2, 4)));
             assert_eq!(i.next().unwrap(),
-            Event::Mouse(MouseEvent::Release(2, 4)));
+            Event::Mouse(MouseEvent::Release(None, 2, 4)));
             assert_eq!(i.next().unwrap(), Event::Key(Key::Char('b')));
             assert!(i.next().is_none());
         }


### PR DESCRIPTION
# Problem
* Mouse tracking when hold middle or right button doesn't work on xterm
* Release any button trigger a release

# Solution
According to : [xterm documentation](https://invisible-island.net/xterm/ctlseqs/ctlseqs.html#h3-Button-event-tracking)

Xterm event on mouse tracking are sending 32/33/34 when left/middle/right button is hold.
We can then provide such information in MouseHold/MouseRelease event.

This allow to drag mouse with middle/right button

Tested on kitty/xterm/konsole

# Caveats
Rxvt seems not to send hold events so this will not benefice for it.
Mouse Event enum are changing therefore it will need a code update for users