### PR TITLE
Fix keys example for alt

### DIFF
--- a/examples/keys.rs
+++ b/examples/keys.rs
@@ -26,9 +26,9 @@ fn main() {
 
         match c.unwrap() {
             Key::Char('q') => break,
+            Key::Alt(c) => println!("*{}", c),
             Key::Char(c) => println!("{}", c),
-            Key::Alt(c) => println!("^{}", c),
-            Key::Ctrl(c) => println!("*{}", c),
+            Key::Ctrl(c) => println!("^{}", c),
             Key::Esc => println!("ESC"),
             Key::Left => println!("←"),
             Key::Right => println!("→"),


### PR DESCRIPTION
Hello,

I have moved the `Key::Alt` match before the `Key::Char` match, otherwise it never matches. I mean arguably the example might as well show the alt characters (e.g. √ for Alt+v for me) but in this case it seems the `Key::Alt` would never match as far as I can tell.

Not sure what your take is on this but I have also swapped "*" and "^" since the latter usually means CTRL.

Best,
Mickael