### PR TITLE
Add CSI sequence for clearing scrollback buffer

### DIFF
--- a/src/clear.rs
+++ b/src/clear.rs
@@ -3,6 +3,7 @@
 use std::fmt;
 
 derive_csi_sequence!("Clear the entire screen.", All, "2J");
+derive_csi_sequence!("Clear the entire scrollback buffer.", Scrollback, "3J");
 derive_csi_sequence!("Clear everything after the cursor.", AfterCursor, "J");
 derive_csi_sequence!("Clear everything before the cursor.", BeforeCursor, "1J");
 derive_csi_sequence!("Clear the current line.", CurrentLine, "2K");


### PR DESCRIPTION
Add the sequence `<CSI>3J` for clearing the scrollback buffer to clear.rs

Reference:
https://en.wikipedia.org/wiki/ANSI_escape_code#ED